### PR TITLE
Add installation and compilation scripts for ROS1

### DIFF
--- a/ros1/.gitignore
+++ b/ros1/.gitignore
@@ -1,0 +1,8 @@
+# Vim files
+*.swp
+
+# Chroot directories
+# cache is a symbolic link
+cache
+focal-armhf/
+focal-arm64/

--- a/ros1/bootstrap-chroot-32.sh
+++ b/ros1/bootstrap-chroot-32.sh
@@ -1,0 +1,1 @@
+../ros2/bootstrap-chroot-32.sh

--- a/ros1/bootstrap-chroot-64.sh
+++ b/ros1/bootstrap-chroot-64.sh
@@ -1,0 +1,1 @@
+../ros2/bootstrap-chroot-64.sh

--- a/ros1/chroot-env-vars.sh
+++ b/ros1/chroot-env-vars.sh
@@ -1,0 +1,211 @@
+#!/bin/bash
+
+# [ -z "${VAR}" ] && echo "unset" || echo "set"
+[ -z "${SOURCED_CHROOT_ENV_VARS_SH}" ] || return
+
+readonly DEBIAN_MIRROR='http://deb.debian.org/debian'
+readonly DEBIAN_SECURITY_MIRROR='http://security.debian.org/debian-security'
+readonly DEBIAN_12_SUITE='bookworm'
+readonly DEBIAN_12_SECURITY_SUITE="${DEBIAN_12_SUITE}-security"
+readonly DEBIAN_ARM32_KERNEL_PACKAGE='linux-image-armmp'
+readonly DEBIAN_ARM64_KERNEL_PACKAGE='linux-image-arm64'
+
+readonly UBUNTU_MAIN_MIRROR='http://archive.ubuntu.com/ubuntu'
+readonly UBUNTU_MAIN_SECURITY_MIRROR='http://security.ubuntu.com/ubuntu'
+readonly UBUNTU_PORT_MIRROR='http://ports.ubuntu.com/ubuntu-ports'
+readonly UBUNTU_PORT_SECURITY_MIRROR="${UBUNTU_PORT_MIRROR}"
+readonly UBUNTU_2004_SUITE='focal'
+readonly UBUNTU_2004_SECURITY_SUITE="${UBUNTU_2004_SUITE}-security"
+readonly UBUNTU_2204_SUITE='jammy'
+readonly UBUNTU_2204_SECURITY_SUITE="${UBUNTU_2204_SUITE}-security"
+readonly UBUNTU_2004_ARM32_KERNEL_PACKAGE='linux-generic-hwe-20.04'
+readonly UBUNTU_2004_ARM64_KERNEL_PACKAGE='linux-generic-hwe-20.04'
+readonly UBUNTU_2204_ARM32_KERNEL_PACKAGE='linux-generic-hwe-22.04'
+readonly UBUNTU_2204_ARM64_KERNEL_PACKAGE='linux-generic-hwe-22.04'
+readonly UBUNTU_ARM32_KERNEL_PACKAGE="${UBUNTU_2004_ARM32_KERNEL_PACKAGE}"
+readonly UBUNTU_ARM64_KERNEL_PACKAGE="${UBUNTU_2004_ARM64_KERNEL_PACKAGE}"
+
+readonly DEBOOTSTRAP_MIRROR="${UBUNTU_PORT_MIRROR}"
+readonly DEBOOTSTRAP_SECURITY_MIRROR="${UBUNTU_PORT_SECURITY_MIRROR}"
+readonly DEBOOTSTRAP_SUITE="${UBUNTU_2004_SUITE}"
+readonly DEBOOTSTRAP_SECURITY_SUITE="${UBUNTU_2004_SECURITY_SUITE}"
+
+readonly ARM32_KERNEL_PACKAGE="${UBUNTU_ARM32_KERNEL_PACKAGE}"
+readonly ARM64_KERNEL_PACKAGE="${UBUNTU_ARM64_KERNEL_PACKAGE}"
+
+readonly ARM32_ARCH='armhf'
+readonly ARM64_ARCH='arm64'
+
+readonly QEMU_USER_STATIC_ARM32_LOCATION='/usr/bin/qemu-arm-static'
+readonly QEMU_USER_STATIC_ARM64_LOCATION='/usr/bin/qemu-aarch64-static'
+
+readonly ARM32_CHROOT="${DEBOOTSTRAP_SUITE}-${ARM32_ARCH}"
+readonly ARM64_CHROOT="${DEBOOTSTRAP_SUITE}-${ARM64_ARCH}"
+
+readonly ARM32_CHROOT_CACHE="$(pwd)/cache/${DEBOOTSTRAP_SUITE}-${ARM32_ARCH}"
+readonly ARM64_CHROOT_CACHE="$(pwd)/cache/${DEBOOTSTRAP_SUITE}-${ARM64_ARCH}"
+
+readonly CHROOTED_USER='softex'
+readonly CHROOTED_USER_PASSWORD='softex'
+
+readonly UNSET_WARNING="is unset or empty"
+
+echo "DEBOOTSTRAP_MIRROR=${DEBOOTSTRAP_MIRROR:?${UNSET_WARNING}}"
+echo "DEBOOTSTRAP_SUITE=${DEBOOTSTRAP_SUITE:?${UNSET_WARNING}}"
+
+echo "ARM32_CHROOT=${ARM32_CHROOT:?${UNSET_WARNING}}"
+echo "ARM64_CHROOT=${ARM64_CHROOT:?${UNSET_WARNING}}"
+
+echo "ARM32_CHROOT_CACHE=${ARM32_CHROOT_CACHE:?${UNSET_WARNING}}"
+echo "ARM64_CHROOT_CACHE=${ARM64_CHROOT_CACHE:?${UNSET_WARNING}}"
+
+echo "ARM32_KERNEL_PACKAGE=${ARM32_KERNEL_PACKAGE:?${UNSET_WARNING}}"
+echo "ARM64_KERNEL_PACKAGE=${ARM64_KERNEL_PACKAGE:?${UNSET_WARNING}}"
+
+echo "CHROOTED_USER=${CHROOTED_USER:?${UNSET_WARNING}}"
+echo "CHROOTED_USER_PASSWORD=${CHROOTED_USER_PASSWORD:?${UNSET_WARNING}}" > /dev/null
+
+if mkdir -p "${ARM32_CHROOT}"; then
+	echo "Created '${ARM32_CHROOT}'"
+else
+	echo "Failed to create '${ARM32_CHROOT}'"
+fi
+if mkdir -p "${ARM64_CHROOT}"; then
+	echo "Created '${ARM64_CHROOT}'"
+else
+	echo "Failed to create '${ARM64_CHROOT}'"
+fi
+
+if mkdir -p "${ARM32_CHROOT_CACHE}"; then
+	echo "Created '${ARM32_CHROOT_CACHE}'"
+else
+	echo "Failed to create '${ARM32_CHROOT_CACHE}'"
+fi
+if mkdir -p "${ARM64_CHROOT_CACHE}"; then
+	echo "Created '${ARM64_CHROOT_CACHE}'"
+else
+	echo "Failed to create '${ARM64_CHROOT_CACHE}'"
+fi
+
+run_debootstrap() {
+	local -r CHROOT_LOCATION="$1"
+	local -r ARCH="$2"
+	local -r CACHE="$3"
+	local -r SUITE="$4"
+	local -r MIRROR="$5"
+	local -r KERNEL_TYPE="$6"
+
+	echo "Bootstraping './${CHROOT_LOCATION}'"
+
+	if debootstrap --arch="${ARCH}" --cache-dir="${CACHE}" "${SUITE}" "./${CHROOT_LOCATION}" "${MIRROR}"; then
+		echo "Initial ${KERNEL_TYPE} system installed"
+	else
+		echo "Failed to install ${KERNEL_TYPE} initial system"
+	fi
+}
+
+copy_qemu_user_static() {
+	local -r QEMU_USER_STATIC_LOCATION="$1"
+	local -r QEMU_USER_STATIC_CHROOT_LOCATION="$2"
+	local -r KERNEL_TYPE="$3"
+
+	if cp "${QEMU_USER_STATIC_LOCATION}" "${QEMU_USER_STATIC_CHROOT_LOCATION}"; then
+		echo "Configured ${KERNEL_TYPE} emulation"
+	else
+		echo "Failed to configure ${KERNEL_TYPE} emulation"
+	fi
+}
+
+mount_chroot() {
+	local -r CHROOT_LOCATION="$1"
+
+	for i in '/dev/pts' '/proc' '/sys'; do
+		if mount --bind "${i}" "./${CHROOT_LOCATION}${i}"; then
+			echo "Bind-mounted ${i} to ${CHROOT_LOCATION}${i}"
+		else
+			echo "Failed to bind mount ${i} to ${CHROOT_LOCATION}${i}"
+		fi
+	done
+}
+
+unmount_chroot() {
+	local -r CHROOT_LOCATION="$1"
+
+	for i in '/dev/pts' '/proc' '/sys'; do
+		if umount "./${CHROOT_LOCATION}${i}"; then
+			echo "Unmounted ${i} from ${CHROOT_LOCATION}${i}"
+		else
+			echo "Failed to unmount ${i} from ${CHROOT_LOCATION}${i}"
+		fi
+	done
+}
+
+run_on_chroot() {
+	local -r args=("$@")
+
+	local -r CHROOT_LOCATION="${args[0]}"
+	local -r CHROOT_USERSPEC="${args[1]}"
+	local -r CHROOT_COMMAND=("${args[@]:2}")
+
+	mount_chroot "${CHROOT_LOCATION}"
+
+	echo "Running '${CHROOT_COMMAND[*]}'"
+
+	if chroot --userspec="${CHROOT_USERSPEC}" "${CHROOT_LOCATION}" "${CHROOT_COMMAND[@]}"; then
+		echo "Executed '${CHROOT_COMMAND[*]}' on '${CHROOT_LOCATION}'"
+	else
+		echo "Failed to execute '${CHROOT_COMMAND[*]}' on '${CHROOT_LOCATION}'"
+	fi
+
+	unmount_chroot "${CHROOT_LOCATION}"
+}
+
+fix_permissions() {
+	local -r FILE="$1"
+
+	local permission
+	local ret
+	permission="$(stat --format='%#04a' "${FILE}")"
+	ret="$?"
+
+	if (( ret == 0 )); then
+		if [[ "${permission}" =~ ..00 ]]; then
+			echo "Will fix '${FILE}' permissions"
+			if chmod 644 "${FILE}"; then
+				echo "Fixed '${FILE}' permissions"
+			else
+				echo "Failed to fix '${FILE}' permission"
+			fi
+		else
+			echo "File '${FILE}' has good permissions"
+		fi
+	else
+		echo "Could not check the permissions of '${FILE}'"
+	fi
+}
+
+create_chrooted_user() {
+	local -r CHROOT_LOCATION="$1"
+	local -r NEW_USER="$2"
+	local -r NEW_USER_UID="$3"
+	local -r NEW_PASSWORD="$4"
+
+	run_on_chroot "${CHROOT_LOCATION}" 'root' useradd --home-dir "/home/${NEW_USER}" --skel '/etc/skel' --create-home --shell '/bin/bash' --groups 'sudo' --uid "${NEW_USER_UID}" "${NEW_USER}"
+	printf "#!/bin/bash\nchpasswd <<< %s:%s" "${NEW_USER}" "${NEW_PASSWORD}" > "${CHROOT_LOCATION}/set-${NEW_USER}-password.sh"
+	chmod 744 "${CHROOT_LOCATION}/set-${NEW_USER}-password.sh"
+	run_on_chroot "${CHROOT_LOCATION}" 'root' "./set-${NEW_USER}-password.sh"
+	rm "${CHROOT_LOCATION}/set-${NEW_USER}-password.sh"
+}
+
+add_security_repo() {
+	local -r CHROOT_LOCATION="$1"
+	local -r SECURITY_MIRROR="$2"
+	local -r SECURITY_SUITE="$3"
+
+	printf "deb %s %s main" "${SECURITY_MIRROR}" "${SECURITY_SUITE}" >> "${CHROOT_LOCATION}/etc/apt/sources.list"
+
+	run_on_chroot "${CHROOT_LOCATION}" 'root' apt update
+	run_on_chroot "${CHROOT_LOCATION}" 'root' apt full-upgrade --yes
+}
+
+readonly SOURCED_CHROOT_ENV_VARS_SH=1

--- a/ros1/installing-native-packages.md
+++ b/ros1/installing-native-packages.md
@@ -1,0 +1,45 @@
+# Installing ROS1 using native packages
+
+ROS1 has been natively packaged [1][1] by the following Debian-based GNU/Linux
+distributions:
+
+- Debian
+    - Stretch (9): ROS 1.7
+    - Buster (10): ROS 1.12
+    - Bullseye (11): ROS 1.16
+    - Bookworm (12): ROS 1.16
+- Ubuntu
+    - Xenial (16.04): ROS 1.5
+    - Bionic (18.04): ROS 1.10
+    - Eoan (19.10): ROS 1.14
+    - Focal (20.04): ROS 1.15
+    - Groovy (20.10): ROS 1.16
+    - Hirsute (21.04): ROS 1.16
+    - Impish (21.10): ROS 1.16
+    - Jammy (22.04): ROS 1.16
+    - Kinetic (22.10): ROS 1.16
+    - Lunar (23.04): ROS 1.16
+
+[1]: https://qa.debian.org/madison.php?package=ros-desktop-full&table=all&a=&c=&s=#
+
+## Installing on Debian-based distributions
+
+Debian-based distributions use `apt` as a front-end for the `dpkg`. Packages
+can be installed using:
+
+```
+apt install the-package-name
+```
+
+### Installing on Debian and Ubuntu
+
+The following important packages are available on the Debian repositories:
+
+- `ros-desktop-full-dev`: `ros-desktop-full` and the dependencies needed to
+compile it
+- `ros-desktop-full`
+- `ros-desktop`: different from the upstream, this package lacks the tutorials
+and `roslint`, which must be compiled from source if needed
+- `ros-base`: provides all the ROS base system
+- `ros-core`: different from the upstream, it lacks `geneus` and
+`rosbag_migration_rule`, which must be compiled from source if needed

--- a/ros1/installing-precompiled-packages.md
+++ b/ros1/installing-precompiled-packages.md
@@ -1,0 +1,54 @@
+# Installing precompiled ROS1 from ROS repositories
+
+If you're using one of the currently supported operating systems, you will be
+able to install precompiled binary packages from ROS1 repositories.
+
+## Compatible operating systems
+
+ROS1 currently packages the ROS ecosystem for the following combinations of
+operating systems and architectures:
+- Ubuntu 20.04 LTS (focal)
+  - amd64
+    - ros-noetic-ros-base
+    - ros-noetic-desktop
+    - ros-noetic-desktop-full
+  - arm64
+    - ros-noetic-ros-base
+    - ros-noetic-desktop
+    - ros-noetic-desktop-full
+  - armhf
+    - ros-noetic-ros-base
+    - ros-noetic-desktop
+
+If you're on a unsopported operating system or architecture, it will be
+necessary to compile the ROS1 ecosystem.
+
+## Instructions for supported systems
+
+### Bootstraping a chroot
+
+This step is required only if you wish to test the installation of ROS2 on a
+ARM-based SBC. The script can be modified to test the installation on an amd64
+Debian-based distribution.
+
+1. Run, with administrator priviledges,the script `bootstrap-chroot-32.sh` or
+`bootstrap-chroot-64.sh`, depending on the Operating System installed on your
+Single Board Computer. This step will be successfull if Git can be successfully
+installed after authorising uts installation.
+
+### Installing on Ubuntu-based Systems
+
+You must run one of the installation scripts. The version will depend on the
+architecture and the operating system on your machine.
+
+Due to limited support of ROS1, this repository only supports 64-bit based ARM
+or AMD64, or 32-bit based ARM (armhf) although the scripts can be easily
+modified to support other architectures and Debian-based operating systems as
+soon as they are available.
+
+1. If you are in a **chroot**, please run, with administrator priviledges, the
+scripts `ubuntu-install-ros1-32-base.sh`, `ubuntu-install-ros1-32-desktop.sh`,
+`ubuntu-install-ros1-64-base.sh`, `ubuntu-install-ros1-64-desktop.sh`,
+`ubuntu-install-ros1-64-desktop-full.sh` depending on the ROS1 packages you wish
+to install.
+2. Authorise the administrative-level operations using your password.

--- a/ros1/installing-precompiled-packages.md
+++ b/ros1/installing-precompiled-packages.md
@@ -7,18 +7,27 @@ able to install precompiled binary packages from ROS1 repositories.
 
 ROS1 currently packages the ROS ecosystem for the following combinations of
 operating systems and architectures:
+
 - Ubuntu 20.04 LTS (focal)
-  - amd64
-    - ros-noetic-ros-base
-    - ros-noetic-desktop
-    - ros-noetic-desktop-full
-  - arm64
-    - ros-noetic-ros-base
-    - ros-noetic-desktop
-    - ros-noetic-desktop-full
-  - armhf
-    - ros-noetic-ros-base
-    - ros-noetic-desktop
+    - amd64
+        - ros-noetic-ros-base
+        - ros-noetic-desktop
+        - ros-noetic-desktop-full
+    - arm64
+        - ros-noetic-ros-base
+        - ros-noetic-desktop
+        - ros-noetic-desktop-full
+    - armhf
+        - ros-noetic-ros-base
+        - ros-noetic-desktop
+- Debian 10 (buster)
+    - amd64
+        - ros-noetic-ros-base
+        - ros-noetic-desktop
+        - ros-noetic-desktop-full
+    - arm64
+        - ros-noetic-ros-base
+        - ros-noetic-desktop
 
 If you're on a unsopported operating system or architecture, it will be
 necessary to compile the ROS1 ecosystem.

--- a/ros1/installing-precompiled-packages.md
+++ b/ros1/installing-precompiled-packages.md
@@ -32,6 +32,38 @@ operating systems and architectures:
 If you're on a unsopported operating system or architecture, it will be
 necessary to compile the ROS1 ecosystem.
 
+### WARNING!
+
+ROS2 precompiled packages are notorious for breaking systems when installed
+without upgrading the system [1][1] [2][2]! Although the installation scripts
+follow the recommended procedures, and ROS1 does not cite that the same problem
+exists for their packages, the risk remains!
+
+You **MUST** have the security repository enabled, as ROS packages are not
+tested on a standard Debian packaging environment and assume that this
+repository will be enabled and that the system is up to date. Please note that
+for Ubuntu, the security repository is different for `amd64` or `armhf`/`arm64`:
+
+- Ubuntu Focal
+    - Security repository for `amd64`:
+`deb http://security.ubuntu.com/ubuntu focal-security main`
+    - Security repository for `arm64` and `armhf`:
+`deb http://ports.ubuntu.com/ubuntu-ports focal-security main`
+- Debian Buster
+    - Security repository for `amd64`, `i386`, `arm64` and `armhf`:
+`deb https://security.debian.org/debian-security buster/updates main`
+
+The precompiled packages also have chronic problems with dependencies even when
+installed on the supported configurations [3][3] [4][4]. If the
+installation fails due to dependency problems, it is advised to compile ROS1
+from source or, if possible, installing the distribution's native packages
+instead of trying to fight the unsatisfiable dependencies.
+
+[1]: https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html
+[2]: https://github.com/ros2/ros2/issues/1272
+[3]: https://github.com/ros2/ros2/issues/1433
+[4]: https://github.com/ros2/ros2/issues/1287
+
 ## Instructions for supported systems
 
 ### Bootstraping a chroot

--- a/ros1/ubuntu-compile-install-ros1-32.sh
+++ b/ros1/ubuntu-compile-install-ros1-32.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+source './chroot-env-vars.sh'
+
+readonly INSTALLATION_SCRIPT='ubuntu-compile-install-ros1-noetic.sh'
+
+cp "${INSTALLATION_SCRIPT}" "${ARM32_CHROOT}/home/${CHROOTED_USER}"
+chmod 755 "${ARM32_CHROOT}/home/${CHROOTED_USER}/${INSTALLATION_SCRIPT}"
+run_on_chroot "${ARM32_CHROOT}" '1000' bash -c "cd /home/${CHROOTED_USER} && USER=${CHROOTED_USER} HOME=/home/${CHROOTED_USER} ./${INSTALLATION_SCRIPT}"

--- a/ros1/ubuntu-compile-install-ros1-64.sh
+++ b/ros1/ubuntu-compile-install-ros1-64.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+source './chroot-env-vars.sh'
+
+readonly INSTALLATION_SCRIPT='ubuntu-compile-install-ros1-noetic.sh'
+
+cp "${INSTALLATION_SCRIPT}" "${ARM64_CHROOT}/home/${CHROOTED_USER}"
+chmod 755 "${ARM64_CHROOT}/home/${CHROOTED_USER}/${INSTALLATION_SCRIPT}"
+run_on_chroot "${ARM64_CHROOT}" '1000' bash -c "cd /home/${CHROOTED_USER} && USER=${CHROOTED_USER} HOME=/home/${CHROOTED_USER} ./${INSTALLATION_SCRIPT}"

--- a/ros1/ubuntu-compile-install-ros1-noetic.sh
+++ b/ros1/ubuntu-compile-install-ros1-noetic.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+# Recommended for a machine with 16 GB of RAM. Trying to go above 8 workers will
+# require more RAM if you do not wish to suffer severe slowdowns due to the
+# trashing or to be surprised with the consequences of triggering the OOM
+# killer.
+# Colcon doesn't really know what should be parallelised, so you will still get
+# ${WORKERS} workers fighting to use all the available cores at once. This
+# causes unnecessary context switches and plenty of cache misses.
+# Going lower or configuring the sequential executor is not recommended, as
+# colcon will refuse to parallelise the lengthy single threaded installation
+# phases, which will waste time on a machine with a SSD or fast HDDs.
+# If you somehow forget to set this variable, the script will try to use the
+# default value detected by colcon, the number of available processors. This
+# includes the SMT threads, if they are available.
+readonly WORKERS=8
+
+if command -v locale > /dev/null; then
+	if grep --quiet 'UTF-8' <<< "$(locale)"; then
+		echo "UTF-8 locale found"
+	else
+		echo "No UTF-8 locales found! Installation may FAIL!"
+		echo "Proposed solution:"
+		echo "Run 'sudo dpkg-reconfigure locales'"
+		echo "Select an UTF-8 locale"
+		echo "Set an UTF-8 locale as the default"
+		echo "Log off and log in before rerunning this script"
+		exit 1
+	fi
+else
+	echo "Please install 'locales' package"
+	exit 2
+fi
+
+# Tools to download code
+# as root
+sudo apt install --yes git wget software-properties-common
+sudo add-apt-repository --yes universe
+
+# ROS repositories where the old python3-vcstool lives
+# THIS WILL OVERWRITE ROS-RELATED SYSTEM PACKAGES!
+# as root
+sudo wget https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -O /usr/share/keyrings/ros-archive-keyring.gpg
+# Using sudo requires care when writing commands with shell redirections
+# echo "data" > special-file
+# echo "data" | sudo tee special-file > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/ros-archive-keyring.gpg arch=$(dpkg --print-architecture)] http://packages.ros.org/ros/ubuntu focal main" | sudo tee /etc/apt/sources.list.d/ros1.list > /dev/null
+sudo apt update
+
+# Tools to download and compile ROS-related code
+# as root
+sudo apt install --yes ros-dev-tools python3-rosinstall-generator
+
+# Create a workspace and clone all repos
+# as other user
+mkdir -pv ros1_noetic/src
+cd ros1_noetic
+rosinstall_generator desktop --rosdistro noetic --deps --tar > noetic-desktop.rosinstall
+vcs import --input noetic-desktop.rosinstall src
+
+# Install even more dependencies
+# as root
+sudo rosdep init
+# as other user
+rosdep update
+rosdep check --from-paths src --ignore-src -y --rosdistro noetic
+printf '#!/bin/bash\n' > ros1-noetic-packages.sh
+printf 'apt install --yes' >> ros1-noetic-packages.sh
+perl -ne 'print " $+{package}" if /apt\s(?<package>.+)/' <<< "$(rosdep check --from-paths src --ignore-src -y --rosdistro noetic 2>/dev/null)" >> ros1-noetic-packages.sh
+chmod +x ros1-noetic-packages.sh
+# as root
+sudo ./ros1-noetic-packages.sh
+
+# Build the code
+# Colcon needs pty devices or it will die before compiling anything.
+# If you're building in a chrooted environment, you must bind mount the required
+# devices.
+# as other user
+# Fixing permissions is not needed if you're compiling as someone other than the
+# super-user.
+# rosdep fix-permissions
+rosdep update
+rosdep check --from-paths src --ignore-src -y --rosdistro noetic
+
+if [[ "$(dpkg --print-architecture)" =~ "amd64" ]]; then
+	echo "Build results will be available at 'install' directory"
+	colcon build --parallel-workers "${WORKERS:=$(nproc)}"
+else
+	# colcon cannot build xmlrpcpp on armhf or arm64
+	echo "WARNING: colcon build of ROS1 is broken on armhf and arm64"
+	echo "Falling back to the recommended legacy catkin_make_isolated"
+	echo "Build results will be available at 'install_isolated' directory"
+	./src/catkin/bin/catkin_make_isolated --install -DCMAKE_BUILD_TYPE=Release --jobs "${WORKERS:=$(nproc)}"
+fi

--- a/ros1/ubuntu-install-ros1-32-base.sh
+++ b/ros1/ubuntu-install-ros1-32-base.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+source './chroot-env-vars.sh'
+
+readonly INSTALLATION_SCRIPT='ubuntu-install-ros1-noetic-base.sh'
+
+cp "${INSTALLATION_SCRIPT}" "${ARM32_CHROOT}/home/${CHROOTED_USER}"
+chmod 755 "${ARM32_CHROOT}/home/${CHROOTED_USER}/${INSTALLATION_SCRIPT}"
+run_on_chroot "${ARM32_CHROOT}" '1000' bash -c "cd /home/${CHROOTED_USER} && USER=${CHROOTED_USER} HOME=/home/${CHROOTED_USER} ./${INSTALLATION_SCRIPT}"

--- a/ros1/ubuntu-install-ros1-32-desktop.sh
+++ b/ros1/ubuntu-install-ros1-32-desktop.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+source './chroot-env-vars.sh'
+
+readonly INSTALLATION_SCRIPT='ubuntu-install-ros1-noetic-desktop.sh'
+
+cp "${INSTALLATION_SCRIPT}" "${ARM32_CHROOT}/home/${CHROOTED_USER}"
+chmod 755 "${ARM32_CHROOT}/home/${CHROOTED_USER}/${INSTALLATION_SCRIPT}"
+run_on_chroot "${ARM32_CHROOT}" '1000' bash -c "cd /home/${CHROOTED_USER} && USER=${CHROOTED_USER} HOME=/home/${CHROOTED_USER} ./${INSTALLATION_SCRIPT}"

--- a/ros1/ubuntu-install-ros1-64-base.sh
+++ b/ros1/ubuntu-install-ros1-64-base.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+source './chroot-env-vars.sh'
+
+readonly INSTALLATION_SCRIPT='ubuntu-install-ros1-noetic-base.sh'
+
+cp "${INSTALLATION_SCRIPT}" "${ARM64_CHROOT}/home/${CHROOTED_USER}"
+chmod 755 "${ARM64_CHROOT}/home/${CHROOTED_USER}/${INSTALLATION_SCRIPT}"
+run_on_chroot "${ARM64_CHROOT}" '1000' bash -c "cd /home/${CHROOTED_USER} && USER=${CHROOTED_USER} HOME=/home/${CHROOTED_USER} ./${INSTALLATION_SCRIPT}"

--- a/ros1/ubuntu-install-ros1-64-desktop-full.sh
+++ b/ros1/ubuntu-install-ros1-64-desktop-full.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+source './chroot-env-vars.sh'
+
+readonly INSTALLATION_SCRIPT='ubuntu-install-ros1-noetic-desktop-full.sh'
+
+cp "${INSTALLATION_SCRIPT}" "${ARM64_CHROOT}/home/${CHROOTED_USER}"
+chmod 755 "${ARM64_CHROOT}/home/${CHROOTED_USER}/${INSTALLATION_SCRIPT}"
+run_on_chroot "${ARM64_CHROOT}" '1000' bash -c "cd /home/${CHROOTED_USER} && USER=${CHROOTED_USER} HOME=/home/${CHROOTED_USER} ./${INSTALLATION_SCRIPT}"

--- a/ros1/ubuntu-install-ros1-64-desktop.sh
+++ b/ros1/ubuntu-install-ros1-64-desktop.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+source './chroot-env-vars.sh'
+
+readonly INSTALLATION_SCRIPT='ubuntu-install-ros1-noetic-desktop.sh'
+
+cp "${INSTALLATION_SCRIPT}" "${ARM64_CHROOT}/home/${CHROOTED_USER}"
+chmod 755 "${ARM64_CHROOT}/home/${CHROOTED_USER}/${INSTALLATION_SCRIPT}"
+run_on_chroot "${ARM64_CHROOT}" '1000' bash -c "cd /home/${CHROOTED_USER} && USER=${CHROOTED_USER} HOME=/home/${CHROOTED_USER} ./${INSTALLATION_SCRIPT}"

--- a/ros1/ubuntu-install-ros1-noetic-base.sh
+++ b/ros1/ubuntu-install-ros1-noetic-base.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Recommended for a machine with 16 GB of RAM. Trying to go above 8 workers will
+# require more RAM if you do not wish to suffer severe slowdowns due to the
+# trashing or to be surprised with the consequences of triggering the OOM
+# killer.
+# Colcon doesn't really know what should be parallelised, so you will still get
+# ${WORKERS} workers fighting to use all the available cores at once. This
+# causes unnecessary context switches and plenty of cache misses.
+# Going lower or configuring the sequential executor is not recommended, as
+# colcon will refuse to parallelise the lengthy single threaded installation
+# phases, which will waste time on a machine with a SSD or fast HDDs.
+# If you somehow forget to set this variable, the script will try to use the
+# default value detected by colcon, the number of available processors. This
+# includes the SMT threads, if they are available.
+readonly WORKERS=8
+
+if command -v locale > /dev/null; then
+	if grep --quiet 'UTF-8' <<< "$(locale)"; then
+		echo "UTF-8 locale found"
+	else
+		echo "No UTF-8 locales found! Installation may FAIL!"
+		echo "Proposed solution:"
+		echo "Run 'sudo dpkg-reconfigure locales'"
+		echo "Select an UTF-8 locale"
+		echo "Set an UTF-8 locale as the default"
+		echo "Log off and log in before rerunning this script"
+		exit 1
+	fi
+else
+	echo "Please install 'locales' package"
+	exit 2
+fi
+
+# Tools to download code
+# as root
+sudo apt install --yes git wget software-properties-common
+sudo add-apt-repository --yes universe
+
+# ROS repositories where the old python3-vcstool lives
+# THIS WILL OVERWRITE ROS-RELATED SYSTEM PACKAGES!
+# as root
+# old ca-certificates from Ubuntu 20 can't validate github's new certificate
+sudo wget --no-check-certificate https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -O /usr/share/keyrings/ros-archive-keyring.gpg
+# Using sudo requires care when writing commands with shell redirections
+# echo "data" > special-file
+# echo "data" | sudo tee special-file > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/ros-archive-keyring.gpg arch=$(dpkg --print-architecture)] http://packages.ros.org/ros/ubuntu focal main" | sudo tee /etc/apt/sources.list.d/ros1.list > /dev/null
+sudo apt update
+
+# Install basic ROS1
+# ROS packaging, build, and communication libraries.
+# as root
+sudo apt install --yes ros-noetic-ros-base

--- a/ros1/ubuntu-install-ros1-noetic-desktop-full.sh
+++ b/ros1/ubuntu-install-ros1-noetic-desktop-full.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Recommended for a machine with 16 GB of RAM. Trying to go above 8 workers will
+# require more RAM if you do not wish to suffer severe slowdowns due to the
+# trashing or to be surprised with the consequences of triggering the OOM
+# killer.
+# Colcon doesn't really know what should be parallelised, so you will still get
+# ${WORKERS} workers fighting to use all the available cores at once. This
+# causes unnecessary context switches and plenty of cache misses.
+# Going lower or configuring the sequential executor is not recommended, as
+# colcon will refuse to parallelise the lengthy single threaded installation
+# phases, which will waste time on a machine with a SSD or fast HDDs.
+# If you somehow forget to set this variable, the script will try to use the
+# default value detected by colcon, the number of available processors. This
+# includes the SMT threads, if they are available.
+readonly WORKERS=8
+
+if command -v locale > /dev/null; then
+	if grep --quiet 'UTF-8' <<< "$(locale)"; then
+		echo "UTF-8 locale found"
+	else
+		echo "No UTF-8 locales found! Installation may FAIL!"
+		echo "Proposed solution:"
+		echo "Run 'sudo dpkg-reconfigure locales'"
+		echo "Select an UTF-8 locale"
+		echo "Set an UTF-8 locale as the default"
+		echo "Log off and log in before rerunning this script"
+		exit 1
+	fi
+else
+	echo "Please install 'locales' package"
+	exit 2
+fi
+
+# Tools to download code
+# as root
+sudo apt install --yes git wget software-properties-common
+sudo add-apt-repository --yes universe
+
+# ROS repositories where the old python3-vcstool lives
+# THIS WILL OVERWRITE ROS-RELATED SYSTEM PACKAGES!
+# as root
+# old ca-certificates from Ubuntu 20 can't validate github's new certificate
+sudo wget --no-check-certificate https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -O /usr/share/keyrings/ros-archive-keyring.gpg
+# Using sudo requires care when writing commands with shell redirections
+# echo "data" > special-file
+# echo "data" | sudo tee special-file > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/ros-archive-keyring.gpg arch=$(dpkg --print-architecture)] http://packages.ros.org/ros/ubuntu focal main" | sudo tee /etc/apt/sources.list.d/ros1.list > /dev/null
+sudo apt update
+
+# Install full ROS1
+# 2D and 3D simulators and perception packages, rqt, rviz, ROS packaging, build,
+# and communication libraries.
+# as root
+sudo apt install --yes ros-noetic-desktop-full

--- a/ros1/ubuntu-install-ros1-noetic-desktop.sh
+++ b/ros1/ubuntu-install-ros1-noetic-desktop.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Recommended for a machine with 16 GB of RAM. Trying to go above 8 workers will
+# require more RAM if you do not wish to suffer severe slowdowns due to the
+# trashing or to be surprised with the consequences of triggering the OOM
+# killer.
+# Colcon doesn't really know what should be parallelised, so you will still get
+# ${WORKERS} workers fighting to use all the available cores at once. This
+# causes unnecessary context switches and plenty of cache misses.
+# Going lower or configuring the sequential executor is not recommended, as
+# colcon will refuse to parallelise the lengthy single threaded installation
+# phases, which will waste time on a machine with a SSD or fast HDDs.
+# If you somehow forget to set this variable, the script will try to use the
+# default value detected by colcon, the number of available processors. This
+# includes the SMT threads, if they are available.
+readonly WORKERS=8
+
+if command -v locale > /dev/null; then
+	if grep --quiet 'UTF-8' <<< "$(locale)"; then
+		echo "UTF-8 locale found"
+	else
+		echo "No UTF-8 locales found! Installation may FAIL!"
+		echo "Proposed solution:"
+		echo "Run 'sudo dpkg-reconfigure locales'"
+		echo "Select an UTF-8 locale"
+		echo "Set an UTF-8 locale as the default"
+		echo "Log off and log in before rerunning this script"
+		exit 1
+	fi
+else
+	echo "Please install 'locales' package"
+	exit 2
+fi
+
+# Tools to download code
+# as root
+sudo apt install --yes git wget software-properties-common
+sudo add-apt-repository --yes universe
+
+# ROS repositories where the old python3-vcstool lives
+# THIS WILL OVERWRITE ROS-RELATED SYSTEM PACKAGES!
+# as root
+# old ca-certificates from Ubuntu 20 can't validate github's new certificate
+sudo wget --no-check-certificate https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -O /usr/share/keyrings/ros-archive-keyring.gpg
+# Using sudo requires care when writing commands with shell redirections
+# echo "data" > special-file
+# echo "data" | sudo tee special-file > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/ros-archive-keyring.gpg arch=$(dpkg --print-architecture)] http://packages.ros.org/ros/ubuntu focal main" | sudo tee /etc/apt/sources.list.d/ros1.list > /dev/null
+sudo apt update
+
+# Install ROS1 with graphical support
+# Rqt, rviz, ROS packaging, build, and communication libraries.
+# as root
+sudo apt install --yes ros-noetic-desktop


### PR DESCRIPTION
- adds scripts for compiling and installing ROS1
- adds scripts to generate suitable chroots for compiling ROS1
- adds scripts to install precompiled ROS1 on Ubuntu
- document how to install precompiled ROS1 using the scripts
- document how to install native ROS1 packages for Debian and Ubuntu

Closes: ResidenciaTICBrisa/03_Robotica#16