### PR TITLE
Scripts de instalação do NAOv6

### DIFF
--- a/docs/mkdocs-kludge.sh
+++ b/docs/mkdocs-kludge.sh
@@ -4,6 +4,7 @@ readonly DOCDIRS=(ros1 ros2 vms/ubuntu-12)
 
 for docdir in "${DOCDIRS[@]}"; do
 	# Create directory inside the current one
+	rm -rv "${docdir}"
 	mkdir -pv "${docdir}"
 
 	dirlevel="$(perl -ne 'print tr/\///' <<< "${docdir}")"

--- a/docs/mkdocs-kludge.sh
+++ b/docs/mkdocs-kludge.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-readonly DOCDIRS=(ros1 ros2 vms/ubuntu-12)
+readonly DOCDIRS=(ros1 ros2 vms/ubuntu-12 vms/ubuntu-16)
 
 for docdir in "${DOCDIRS[@]}"; do
 	# Create directory inside the current one

--- a/docs/vms/ubuntu-16/README.md
+++ b/docs/vms/ubuntu-16/README.md
@@ -1,0 +1,1 @@
+../../../scripts/vms/ubuntu-16/README.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,7 +74,7 @@ markdown_extensions:
 
 nav:
   - Home: index.md
-  - Maquina Virtual: Instruções/Maquina_Virtual.md
+  - Máquina Virtual: Instruções/Maquina_Virtual.md
   - NAOv4:
     - Máquina Virtual com scripts: vms/ubuntu-12/README.md
     - NAO Flahser: Instruções/NAO_Flasher.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,10 +76,12 @@ nav:
   - Home: index.md
   - Maquina Virtual: Instruções/Maquina_Virtual.md
   - NAOv4:
+    - Máquina Virtual com scripts: vms/ubuntu-12/README.md
     - NAO Flahser: Instruções/NAO_Flasher.md
     - SDK C++: Instruções/CPP_SDK_v4.md
     - Choregraphe: Instruções/Choregraphe_v4.md
   - NAOv6:
+    - Máquina Virtual com scripts: vms/ubuntu-16/README.md
     - Robot Settings: Instruções/Robot_Settings.md
     - SDK C++: Instruções/CPP_SDK.md
     - Choregraphe: Instruções/Choregraphe_v6.md

--- a/scripts/vms/ubuntu-16/.gitignore
+++ b/scripts/vms/ubuntu-16/.gitignore
@@ -1,0 +1,7 @@
+# Vim swap files
+*.swp
+
+# QEMU disks
+*.qcow2
+*.qcow
+*.iso

--- a/scripts/vms/ubuntu-16/README.md
+++ b/scripts/vms/ubuntu-16/README.md
@@ -32,7 +32,7 @@ Even though these scripts can be modified easily, they expect the following
 directory structure in their current form:
 
 - `env-vars.sh`, a script to centralise the VM's configurations
-- an image [1][1] from Ubuntu's installation disk version 16.04 named as
+- an [image][1] from Ubuntu's installation disk version 16.04 named as
 `ubuntu-16.04-desktop-amd64.iso` (this can be altered in the `IMAGE_LOCATION`
 variable at the `env-vars.sh` script)
 

--- a/scripts/vms/ubuntu-16/README.md
+++ b/scripts/vms/ubuntu-16/README.md
@@ -1,0 +1,206 @@
+# Set up and run a VM for developing NAOv6-based solutions
+
+## Setup
+
+The scripts are flexible, but they still have requirements in order to be run.
+
+### Packages
+
+These scripts need the following packages to be installed on the host's system
+(assuming a Debian GNU/Linux based distribution, such as Ubuntu, Linux Mint):
+
+|Package         |Version|
+|----------------|-------|
+|qemu-system-x86 |6.2.0  |
+|qemu-utils      |6.2.0  |
+|qemu-system-gui |6.2.0  |
+|qemu-block-extra|6.2.0  |
+|ovmf            |2022.11|
+|libguestfs-tools|1.48.6 |
+
+The scripts assume that KVM-based accelerated virtualisation is enabled on the
+host machine. This requires a compatible processor and it may require a
+configuration in the UEFI/BIOS (AMD-V, AMD SVM, Intel VT, Intel VT-x,
+Intel VMX).
+
+The package `cpu-checker` is able to verify if KVM is correctly enabled: one
+only needs to run the command `kvm-ok` as superuser.
+
+### Expected directory structure
+
+Even though these scripts can be modified easily, they expect the following
+directory structure in their current form:
+
+- `env-vars.sh`, a script to centralise the VM's configurations
+- an image [1][1] from Ubuntu's installation disk version 16.04 named as
+`ubuntu-16.04-desktop-amd64.iso` (this can be altered in the `IMAGE_LOCATION`
+variable at the `env-vars.sh` script)
+
+[1]: https://releases.ubuntu.com/releases/xenial/ubuntu-16.04.7-desktop-amd64.iso
+
+### Creating the VM and preparing to compile NAOqi for NAOv6
+
+The user must run in their host machine the scripts inside this repository in
+the following order:
+
+1. `reset-main-drive.sh`
+2. `first-boot.sh`
+
+After installing Ubuntu 16.04 in their virtual machine, the following scripts
+must be executed in their host machine:
+
+1. `update-sources.sh`
+2. `inject-home.sh`
+
+Now, inside the virtual machine, also known as the guest machine, the user
+must run the `prepare-naoqi-requirements.sh` script to install Pip 20.3.4.
+
+Finally, the user will be able to install the NAOv6 development environment
+using the `install-naov6.sh` script.
+
+## Starting the Virtual Machine up for the first time
+
+The initial images are created by the `reset-*` scripts
+
+```
+./reset-main-drive.sh
+```
+
+With the drives created, run the initialisation script and install a regular
+Ubuntu 16.04 LTS installation:
+
+- Language and keyboard layout: Português Brasileiro
+- Erase disk and install Ubuntu
+- Timezone: Sao Paulo
+- User: softex
+
+```
+./first-boot.sh
+```
+
+## Running the VM
+
+Sometimes the Brazilian server takes too long to synchronise with the main
+server, leading to failed installations or upgrades. In order to avoid this
+problem, please run the following script to set the repository to the main
+archive:
+
+```
+./update-sources.sh
+```
+
+Don't forget to update (`apt update`) and upgrade (`apt dist-upgrade`) if there
+are any updates available.
+
+## Preparing to install NAOqi for NAOv6
+
+Ubuntu 16.04 has an old version of `pip`. This requires an installation of the
+last Python 2 compatible release to be able to download the packages and their
+dependencies. These steps can be automated by sending a script to the user's
+home on the VM:
+
+```
+./inject-home.sh
+```
+
+After the script is sent to the user's home, it must be executed in the VM. It
+will propmpt for administrative privileges before updating the repository and
+installing dependencies for installing Pip:
+
+```
+./prepare-naoqi-requirements.sh
+```
+
+## Installing NAOv6 development environment
+
+After running the preparation script, the installation one must be run on a
+new terminal session. If you wish to remain in the same session, you must reload
+your `.bashrc` (`source .bashrc`) to enable the modifications made to enable
+PIP2 and its binaries.
+
+```
+./install-naov6.sh
+```
+
+This script will also prompt for administrative rights, as it needs to install
+packages used by the C++ and Python2 SDKs.
+
+### Activating Choregraphe
+
+Choregraphe may prompt for its activation key on its first initialisation. This
+key is available in the installation script, and it will also be printed to the
+terminal after the script is executed.
+
+### Configuring the host USB
+
+The `env-vars.sh` script has four variables to control how the virtual machine
+will connect to the host USB device:
+
+- `USB_HOST_BUS`: the bus' ID, including leading zeros
+- `USB_HOST_ADDRESS`: the device's ID in the aforementioned bus, including leading
+zeros
+- `USB_VENDOR_ID`: the device's vendor ID in hexadecimal notation, that is, the
+device's vendor ID preceded by `0x`
+- `USB_PRODUCT_ID`: the device's product ID in hexadecimal notation, that is,
+the device's product ID preceded by `0x`
+
+The variables match the output of the `lsusb` command:
+
+```
+Bus $USB_HOST_BUS Device $USB_HOST_ADDRESS: ID $USB_VENDOR_ID:$USB_PRODUCT_ID MyUSB Device Thing
+```
+
+There are two scripts that will connect the host's device to the virtual
+machine:
+
+- `run-usb-productid.sh`: connects only the device with the matching vendor and
+product ID as long as it is connected to the specified port. It requires
+specifying all the four variables;
+- `run-usb-hostid.sh`: connects anything currenctly connected to the specified
+port. It requires specifying only the bus and the device.
+
+The virtualiser uses the `/dev/bus/usb` files to connect the VM to the host
+device. This requires superuser permissions on most machines. In order to
+connect a host USB device to the VM, the user must provide the script with the
+necessary privileges (run it as root, prefix with `sudo`) or change the
+permissions of the USB interface (changing its group with `chgrp` to a group
+that it user takes part in, or changing its owner with `chown`).
+
+#### Example
+
+Consider the following `lsusb` output:
+
+```
+Bus 001 Device 001: ID 0001:0001 USB Thing 1
+Bus 001 Device 002: ID 0001:0002 USB Thing 2
+Bus 001 Device 003: ID 0001:0001 USB Thing 1
+Bus 002 Device 001: ID 0002:0001 USB Device 1
+Bus 002 Device 002: ID 0002:0002 USB Device 2
+Bus 002 Device 003: ID 0002:0001 USB Device 1
+```
+
+If one wishes to connect the `USB Thing 1` connected at the `Bus 001` as the
+device numbered `003`, they should configure the variables at `env-vars.sh` as:
+
+```
+USB_HOST_BUS="001"
+USB_HOST_ADDRESS="003"
+USB_VENDOR_ID="0x0001"
+USB_PRODUCT_ID="0x0001"
+```
+
+Before running the desired script, the permissions must be set for the USB file
+(`chown the-user /dev/bus/usb/001/003`) or the script must be run with elevated
+privileges (`sudo` or run as root).
+
+Please be aware that in order to connect only the required device to the VM, one
+must run the VM using `run-usb-productid.sh`. Choosing the
+`run-usb-productid.sh` would connect all the devices connected to the `Bus 001`,
+the two `USB Thing 1` and the `USB Thing 2`.
+
+
+### NAO Flasher permissions
+
+NAO Flasher requires administrative permissions (`sudo` or execution as the
+`root` user) to write data. If `sudo` can't find the program's path, you may
+find it with `command -v flasher`.

--- a/scripts/vms/ubuntu-16/compress-drive.sh
+++ b/scripts/vms/ubuntu-16/compress-drive.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+readonly DRIVE="$1"
+readonly DRIVE_BACKUP="${DRIVE}_backup"
+
+usage()
+{
+	printf "Converts image to QCOW2 and compresses it\n"
+	printf "Usage:\tcompress-drive drive-to-compress\n"
+	printf "The image is backed up with a '_backup' suffix\n"
+
+	exit 1
+}
+
+missing_drive()
+{
+	printf "Drive specified on '%s' was not found\n" "${1}"
+	exit 2
+}
+
+[ -n "${DRIVE}" ] || usage
+
+if [ -f "${DRIVE}" ]; then
+	printf "DRIVE=%s\n" "${DRIVE}"
+else
+	missing_drive "${DRIVE}"
+fi
+
+printf "Converting to QCOW2 and compressing %s\n" "${DRIVE}"
+mv "${DRIVE}" "${DRIVE_BACKUP}"
+sync
+qemu-img convert -c -p -O qcow2 "${DRIVE_BACKUP}" "${DRIVE}"
+#qemu-img convert --salvage -c -p -O qcow2 "${DRIVE_BACKUP}" "${DRIVE}"
+sync

--- a/scripts/vms/ubuntu-16/env-vars.sh
+++ b/scripts/vms/ubuntu-16/env-vars.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# [ -z "${VAR}" ] && echo "unset" || echo "set"
+[ -z "${SOURCED_ENV_VARS_SH}" ] || exit 0
+
+readonly BIOS_LOCATION="/usr/share/OVMF/OVMF_CODE.fd"
+readonly IMAGE_LOCATION="ubuntu-16.04-desktop-amd64.iso"
+readonly DISK_LOCATION="ubuntu-16.04-vm.qcow2"
+
+readonly DISK_SIZE="50G"
+
+readonly VM_INITIAL_NAME="ubuntu-16.04-nao-first-boot"
+readonly VM_NAME="ubuntu-16.04-nao"
+readonly IPV4_NETWORK="192.168.3.0/24"
+readonly IPV4_DHCP_FIRST_ADDR="192.168.3.220"
+readonly P22_FWD="10022"
+readonly MACHINE_TYPE="pc-q35-6.2"
+readonly MACHINE_CFG="type=${MACHINE_TYPE},accel=kvm"
+readonly CPU_MODEL="Haswell-v4"
+readonly CPU_NUMBER="4"
+readonly MACHINE_MEMORY_SIZE="4G"
+readonly DISPLAY_DEVICE="virtio-vga-gl"
+readonly DISPLAY_BACKEND="gtk,gl=on"
+
+readonly VM_USER="softex"
+
+readonly USB_HOST_BUS=""
+readonly USB_HOST_ADDRESS=""
+
+readonly USB_VENDOR_ID=""
+readonly USB_PRODUCT_ID=""
+
+readonly UNSET_WARNING="is unset or empty"
+
+echo "BIOS_LOCATION=${BIOS_LOCATION:?${UNSET_WARNING}}"
+echo "IMAGE_LOCATION=${IMAGE_LOCATION:?${UNSET_WARNING}}"
+echo "DISK_LOCATION=${DISK_LOCATION:?${UNSET_WARNING}}"
+
+echo "DISK_SIZE=${DISK_SIZE:?${UNSET_WARNING}}"
+
+echo "VM_INITIAL_NAME=${VM_INITIAL_NAME:?${UNSET_WARNING}}"
+echo "VM_NAME=${VM_NAME:?${UNSET_WARNING}}"
+
+echo "VM_USER=${VM_USER:?${UNSET_WARNING}}"
+
+echo "IPV4_NETWORK=${IPV4_NETWORK:?${UNSET_WARNING}}"
+echo "IPV4_DHCP_FIRST_ADDR=${IPV4_DHCP_FIRST_ADDR:?${UNSET_WARNING}}"
+echo "P22_FWD=${P22_FWD:?${UNSET_WARNING}}"
+echo "MACHINE_TYPE=${MACHINE_TYPE:?${UNSET_WARNING}}"
+echo "MACHINE_CFG=${MACHINE_CFG:?${UNSET_WARNING}}"
+echo "CPU_MODEL=${CPU_MODEL:?${UNSET_WARNING}}"
+echo "CPU_NUMBER=${CPU_NUMBER:?${UNSET_WARNING}}"
+echo "MACHINE_MEMORY_SIZE=${MACHINE_MEMORY_SIZE:?${UNSET_WARNING}}"
+
+abort_if_bios_not_found() {
+	if [[ ! -e "${BIOS_LOCATION}" ]]; then
+		echo "UEFI/BIOS not found on '${BIOS_LOCATION}'"
+		echo "Try 'apt install ovmf' or 'apt install seabios'"
+		exit 1
+	fi
+}
+
+abort_if_image_not_found() {
+	if [[ ! -e "${IMAGE_LOCATION}" ]]; then
+		echo "Installation image not found on '${IMAGE_LOCATION}'"
+		exit 2
+	fi
+}
+
+abort_if_disk_not_found() {
+	if [[ ! -e "${DISK_LOCATION}" ]]; then
+		echo "Virtual Machine disk not found on '${DISK_LOCATION}'"
+		exit 3
+	fi
+}
+
+readonly SOURCED_ENV_VARS_SH=1

--- a/scripts/vms/ubuntu-16/first-boot.sh
+++ b/scripts/vms/ubuntu-16/first-boot.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+source './env-vars.sh'
+
+echo "Booting machine '${VM_INITIAL_NAME}' with HDD from removable media"
+
+abort_if_bios_not_found
+
+abort_if_image_not_found
+abort_if_disk_not_found
+
+qemu-system-x86_64 \
+-k pt-br \
+-machine "${MACHINE_CFG}" \
+-cpu "${CPU_MODEL}" -smp "${CPU_NUMBER}" \
+-m "${MACHINE_MEMORY_SIZE}" \
+-bios "${BIOS_LOCATION}" \
+-device virtio-scsi-pci,id=scsi0 \
+-drive file="${IMAGE_LOCATION}",format=raw,if=none,media=cdrom,index=0,id=drive-cd1,readonly=on \
+-device scsi-cd,bus=scsi0.0,drive=drive-cd1,id=cd1,bootindex=0 \
+-drive file="${DISK_LOCATION}",format=qcow2,if=none,media=disk,index=1,id=drive-hd1,readonly=off \
+-device scsi-hd,bus=scsi0.0,drive=drive-hd1,id=hd1,bootindex=1 \
+-device qemu-xhci \
+-boot menu=on \
+-netdev user,id=net0,net="${IPV4_NETWORK}",dhcpstart="${IPV4_DHCP_FIRST_ADDR}",hostfwd=tcp::"${P22_FWD}"-:22 \
+-device virtio-net-pci,netdev=net0 \
+-rtc base=localtime,clock=vm \
+-device "${DISPLAY_DEVICE}" \
+-display "${DISPLAY_BACKEND}" \
+-monitor stdio \
+-name "${VM_INITIAL_NAME}"

--- a/scripts/vms/ubuntu-16/inject-home.sh
+++ b/scripts/vms/ubuntu-16/inject-home.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/guestfish -f
+
+# Ugly hack yet necessary, as guestfish lacks variables
+# Guestfish asks 'sh' to interpret the inline script and will happily try to
+# execute whathever 'sh' sent to stdout
+<!. ./env-vars.sh > /dev/null; echo "add '${DISK_LOCATION}'"
+run
+mount '/dev/sda2' '/'
+
+#!mkdir -p 'push-to-home.d'
+
+<!. ./env-vars.sh > /dev/null; echo "copy-in 'prepare-naoqi-requirements.sh' '/home/${VM_USER}'"
+
+<!. ./env-vars.sh > /dev/null; echo "copy-in 'install-naov6.sh' '/home/${VM_USER}'"
+<!. ./env-vars.sh > /dev/null; echo "copy-in 'naov6-qibuild.xml' '/home/${VM_USER}'"
+
+echo ""
+
+echo "Unmounting..."
+umount-all
+
+echo "Done"
+
+exit

--- a/scripts/vms/ubuntu-16/install-naov6.sh
+++ b/scripts/vms/ubuntu-16/install-naov6.sh
@@ -139,7 +139,7 @@ done
 echo 'Installing Python library'
 echo '# NAOv6 Python SDK' >> "${HOME}/.bashrc"
 echo "readonly NAO6_PYTHON_SDK_PATH=\"${NAO_PYTHON2_DIR}/${NAOQI_PYTHON}\"" >> "${HOME}/.bashrc"
-echo 'export PYTHONPATH="${PYTHONPATH}:${NAO6_PYTHON_SDK_PATH}"' >> "${HOME}/.bashrc"
+echo 'export PYTHONPATH="${PYTHONPATH}:${NAO6_PYTHON_SDK_PATH}/lib/python2.7/site-packages"' >> "${HOME}/.bashrc"
 
 echo 'Installing Choreographe'
 echo '# Choregraphe path' >> "${HOME}/.bashrc"

--- a/scripts/vms/ubuntu-16/install-naov6.sh
+++ b/scripts/vms/ubuntu-16/install-naov6.sh
@@ -72,6 +72,7 @@ mkdir -pv "${NAO_PROGRAMS_DIR}"
 mkdir -pv "${NAO_DOCS_DIR}"
 mkdir -pv "${NAO_CHOREGRAPHE_DIR}"
 mkdir -pv "${NAO_FLASHER_DIR}"
+mkdir -pv "${NAO_ROBOT_SETTINGS_DIR}"
 
 echo 'Install qibuild'
 pip2 install qibuild pyreadline
@@ -150,6 +151,11 @@ echo 'Installing NAO Flasher'
 echo '# NAO Flasher path' >> "${HOME}/.bashrc"
 echo "readonly NAO_FLASHER_PATH=\"${NAO_FLASHER_DIR}/${NAO_FLASHER}\"" >> "${HOME}/.bashrc"
 echo 'export PATH="${PATH}:${NAO_FLASHER_PATH}"' >> "${HOME}/.bashrc"
+
+echo 'Installing Robot Settings'
+echo '# Robot Settings path' >> "${HOME}/.bashrc"
+echo "readonly NAO_ROBOT_SETTINGS_PATH=\"${NAO_ROBOT_SETTINGS_DIR}/${NAO_ROBOT_SETTINGS_BINARIES}/bin\"" >> "${HOME}/.bashrc"
+echo 'export PATH="${PATH}:${NAO_ROBOT_SETTINGS_PATH}"' >> "${HOME}/.bashrc"
 
 echo 'Installing CPP library'
 "${PIP_PATH}/qitoolchain" create "${NAOQI_CPP_QIBUILD_TOOLCHAIN}" "${NAO_CPP_DIR}/${NAOQI_CPP}/toolchain.xml"

--- a/scripts/vms/ubuntu-16/install-naov6.sh
+++ b/scripts/vms/ubuntu-16/install-naov6.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+
+readonly PIP_PATH="${HOME}/.local/bin"
+
+readonly CURRENT_DIR="$(pwd)"
+
+readonly NAO_CPP_DIR="${HOME}/NAO6/SDKs/cpp"
+readonly NAO_PYTHON2_DIR="${HOME}/NAO6/SDKs/python2"
+readonly NAO_DOWNLOADS_DIR="${HOME}/NAO6/downloads"
+readonly NAO_PROGRAMS_DIR="${HOME}/NAO6/programs"
+readonly NAO_DOCS_DIR="${HOME}/NAO6/docs"
+
+readonly NAO_CHOREGRAPHE_DIR="${NAO_PROGRAMS_DIR}/choregraphe"
+readonly CHOREGRAPHE_KEY='654e-4564-153c-6518-2f44-7562-206e-4c60-5f47-5f45'
+
+readonly NAO_FLASHER_DIR="${NAO_PROGRAMS_DIR}/flasher"
+readonly NAO_ROBOT_SETTINGS_DIR="${NAO_PROGRAMS_DIR}/robot-settings"
+
+readonly NAOQI_CPP_QIBUILD_TOOLCHAIN='naov6-toolchain'
+readonly NAOQI_CPP_QIBUILD_CONFIG="${NAOQI_CPP_QIBUILD_TOOLCHAIN}-config"
+
+# readonly NAOQI_CMAKE_CONFIG='naov6-config.cmake'
+readonly QIBUILD_CONFIGURATION='naov6-qibuild.xml'
+
+readonly NAOQI_DOCS_URL='http://doc.aldebaran.com/download/aldeb-doc-2.8.7.4.zip'
+readonly CHOREGRAPHE_SETUP_URL='https://community-static.aldebaran.com/resources/2.8.7/Choregraphe+Suite/Linux64/choregraphe-suite-2.8.7.4-linux64-setup.run'
+readonly CHOREGRAPHE_BINARIES_URL='https://community-static.aldebaran.com/resources/2.8.7/Choregraphe+Suite/Linux64/choregraphe-suite-2.8.7.4-linux64.tar.gz'
+readonly NAOQI_CPP_URL='https://community-static.aldebaran.com/resources/2.8.5/naoqi-sdk-2.8.5.10-linux64.tar.gz'
+readonly NAOQI_PYTHON_URL='https://community-static.aldebaran.com/resources/2.8.7/Python+SDK/pynaoqi-python2.7-2.8.7.4-linux64-20210819_141148.tar.gz'
+readonly NAO_FLASHER_URL='https://community-static.aldebaran.com/resources/2.1.0.19/flasher-2.1.0.19-linux64.tar.gz'
+readonly NAO_ROBOT_SETTINGS_SETUP_URL='https://community-static.aldebaran.com/resources/2.8.7/Robot+settings+1.2.1/Linux64/robot-settings_linux64_1.2.1-6c3a1204f_20210902-182550_setup.run'
+readonly NAO_ROBOT_SETTINGS_BINARIES_URL='https://community-static.aldebaran.com/resources/2.8.7/Robot+settings+1.2.1/Linux64/robot-settings_linux64_1.2.1-6c3a1204f_20210902-182550.tar.gz'
+
+readonly NAOQI_DOCS_FILE="${NAOQI_DOCS_URL##*/}"
+readonly CHOREGRAPHE_SETUP_FILE="${CHOREGRAPHE_SETUP_URL##*/}"
+readonly CHOREGRAPHE_BINARIES_FILE="${CHOREGRAPHE_BINARIES_URL##*/}"
+readonly NAOQI_CPP_FILE="${NAOQI_CPP_URL##*/}"
+readonly NAOQI_PYTHON_FILE="${NAOQI_PYTHON_URL##*/}"
+readonly NAO_FLASHER_FILE="${NAO_FLASHER_URL##*/}"
+readonly NAO_ROBOT_SETTINGS_SETUP_FILE="${NAO_ROBOT_SETTINGS_SETUP_URL##*/}"
+readonly NAO_ROBOT_SETTINGS_BINARIES_FILE="${NAO_ROBOT_SETTINGS_BINARIES_URL##*/}"
+
+readonly NAOQI_DOCS="${NAOQI_DOCS_FILE%*.zip}"
+readonly CHOREGRAPHE_BINARIES="${CHOREGRAPHE_BINARIES_FILE%*.tar.*}"
+readonly NAOQI_CPP="${NAOQI_CPP_FILE%*.tar.*}"
+readonly NAOQI_PYTHON="${NAOQI_PYTHON_FILE%*.tar.*}"
+readonly NAO_FLASHER="${NAO_FLASHER_FILE%*.tar.*}"
+readonly NAO_ROBOT_SETTINGS_BINARIES="${NAO_ROBOT_SETTINGS_BINARIES_FILE%*.tar.*}"
+
+readonly DOWNLOAD_URLS=(
+	"${CHOREGRAPHE_BINARIES_URL}"
+	"${NAOQI_CPP_URL}"
+	"${NAOQI_PYTHON_URL}"
+	"${NAOQI_DOCS_URL}"
+	"${NAO_FLASHER_URL}"
+	"${NAO_ROBOT_SETTINGS_BINARIES_URL}"
+)
+
+readonly ARIA2_JOBS=2
+readonly ARIA2_SPLITS=2
+
+sudo apt-get update
+
+echo 'Install C++, Python dependencies and downloader'
+sudo apt-get install --yes build-essential cmake wget
+
+echo 'Create directories'
+mkdir -pv "${NAO_CPP_DIR}"
+mkdir -pv "${NAO_PYTHON2_DIR}"
+mkdir -pv "${NAO_DOWNLOADS_DIR}"
+mkdir -pv "${NAO_PROGRAMS_DIR}"
+mkdir -pv "${NAO_DOCS_DIR}"
+mkdir -pv "${NAO_CHOREGRAPHE_DIR}"
+mkdir -pv "${NAO_FLASHER_DIR}"
+
+echo 'Install qibuild'
+pip2 install qibuild pyreadline
+echo '# NAOv6 installation' >> "${HOME}/.bashrc"
+echo "readonly PIP_PATH=\"${PIP_PATH}\"" >> "${HOME}/.bashrc"
+echo 'export PATH="${PATH}:${PIP_PATH}"' >> "${HOME}/.bashrc"
+
+echo 'Configure qibuild'
+mkdir -pv "${HOME}/.config/qi"
+mv -v "${QIBUILD_CONFIGURATION}" "${HOME}/.config/qi/qibuild.xml"
+
+cd "${NAO_CPP_DIR}"
+"${PIP_PATH}/qibuild" init
+cd "${CURRENT_DIR}"
+
+echo 'Download packages'
+for url in "${DOWNLOAD_URLS[@]}"; do
+	wget "${url}" --directory-prefix="${NAO_DOWNLOADS_DIR}"
+done
+
+echo 'Extract packages'
+for f in "${NAO_DOWNLOADS_DIR}"/{*.zip,*.tar.gz}; do
+	if [[ "$f" =~ .*\.zip ]]; then
+		unzip -d "${f%*.zip}" "$f"
+	else
+		tar --extract --file="$f" --directory "${NAO_DOWNLOADS_DIR}"
+	fi
+done
+
+echo 'Move packages'
+for f in "${NAO_DOWNLOADS_DIR}"/*; do
+	if [[ -d "$f" ]]; then
+		case "$f" in
+		"${NAO_DOWNLOADS_DIR}/${NAOQI_DOCS}")
+			mv -v "$f" "${NAO_DOCS_DIR}/"
+			;;
+		"${NAO_DOWNLOADS_DIR}/${CHOREGRAPHE_BINARIES}")
+			mv -v "$f" "${NAO_CHOREGRAPHE_DIR}/"
+			;;
+		"${NAO_DOWNLOADS_DIR}/${NAOQI_CPP}")
+			mv -v "$f" "${NAO_CPP_DIR}/"
+			;;
+		"${NAO_DOWNLOADS_DIR}/${NAOQI_PYTHON}")
+			mv -v "$f" "${NAO_PYTHON2_DIR}/"
+			;;
+		"${NAO_DOWNLOADS_DIR}/${NAO_FLASHER}")
+			mv -v "$f" "${NAO_FLASHER_DIR}/"
+			;;
+		"${NAO_DOWNLOADS_DIR}/${NAO_ROBOT_SETTINGS_BINARIES}")
+			mv -v "$f" "${NAO_ROBOT_SETTINGS_DIR}/"
+			;;
+		*)
+			echo "Unknown file '$f'"
+			;;
+		esac
+	else
+		echo "Not a directory: '$f'"
+	fi
+done
+
+# echo 'Patching NAOv6 C++ SDK'
+# mv -v "${NAOQI_CMAKE_CONFIG}" "${NAO_CPP_DIR}/${NAOQI_CPP}/config.cmake"
+
+echo 'Installing Python library'
+echo '# NAOv6 Python SDK' >> "${HOME}/.bashrc"
+echo "readonly NAO6_PYTHON_SDK_PATH=\"${NAO_PYTHON2_DIR}/${NAOQI_PYTHON}\"" >> "${HOME}/.bashrc"
+echo 'export PYTHONPATH="${PYTHONPATH}:${NAO6_PYTHON_SDK_PATH}"' >> "${HOME}/.bashrc"
+
+echo 'Installing Choreographe'
+echo '# Choregraphe path' >> "${HOME}/.bashrc"
+echo "readonly CHOREGRAPHE_PATH=\"${NAO_CHOREGRAPHE_DIR}/${CHOREGRAPHE_BINARIES}\"" >> "${HOME}/.bashrc"
+echo 'export PATH="${PATH}:${CHOREGRAPHE_PATH}"' >> "${HOME}/.bashrc"
+echo "Choregraphe key: '${CHOREGRAPHE_KEY}'"
+
+echo 'Installing NAO Flasher'
+echo '# NAO Flasher path' >> "${HOME}/.bashrc"
+echo "readonly NAO_FLASHER_PATH=\"${NAO_FLASHER_DIR}/${NAO_FLASHER}\"" >> "${HOME}/.bashrc"
+echo 'export PATH="${PATH}:${NAO_FLASHER_PATH}"' >> "${HOME}/.bashrc"
+
+echo 'Installing CPP library'
+"${PIP_PATH}/qitoolchain" create "${NAOQI_CPP_QIBUILD_TOOLCHAIN}" "${NAO_CPP_DIR}/${NAOQI_CPP}/toolchain.xml"
+cd "${NAO_CPP_DIR}"
+"${PIP_PATH}/qibuild" add-config "${NAOQI_CPP_QIBUILD_CONFIG}" -t "${NAOQI_CPP_QIBUILD_TOOLCHAIN}" --default
+cd "${CURRENT_DIR}"
+
+exit 0

--- a/scripts/vms/ubuntu-16/nao6-downloads
+++ b/scripts/vms/ubuntu-16/nao6-downloads
@@ -1,0 +1,18 @@
+# Aldebaran Documentation for NAOqi 2.8
+http://doc.aldebaran.com/download/aldeb-doc-2.8.7.4.zip
+# Choreographe binaries for Linux amd64
+https://community-static.aldebaran.com/resources/2.8.7/Choregraphe+Suite/Linux64/choregraphe-suite-2.8.7.4-linux64.tar.gz
+# Choreographe setup for Linux amd64
+https://community-static.aldebaran.com/resources/2.8.7/Choregraphe+Suite/Linux64/choregraphe-suite-2.8.7.4-linux64-setup.run
+# Cross toolchain for Linux amd64
+https://community-static.aldebaran.com/resources/2.8.7/cross+toolchain/ctc-linux64-atom-2.8.7.4-20210818_162500.zip
+# NAOqi C++ SDK for amd64
+https://community-static.aldebaran.com/resources/2.8.5/naoqi-sdk-2.8.5.10-linux64.tar.gz
+# NAOqi Python 2.7 for Linux amd64
+https://community-static.aldebaran.com/resources/2.8.7/Python+SDK/pynaoqi-python2.7-2.8.7.4-linux64-20210819_141148.tar.gz
+# Robot Settings binaries for Linux amd64
+https://community-static.aldebaran.com/resources/2.8.7/Robot+settings+1.2.1/Linux64/robot-settings_linux64_1.2.1-6c3a1204f_20210902-182550.tar.gz
+# Robot Settings setup for Linux amd64
+https://community-static.aldebaran.com/resources/2.8.7/Robot+settings+1.2.1/Linux64/robot-settings_linux64_1.2.1-6c3a1204f_20210902-182550_setup.run
+# NAO Flasher for Linux amd64
+https://community-static.aldebaran.com/resources/2.1.0.19/flasher-2.1.0.19-linux64.tar.gz

--- a/scripts/vms/ubuntu-16/naov6-qibuild.xml
+++ b/scripts/vms/ubuntu-16/naov6-qibuild.xml
@@ -1,0 +1,7 @@
+<!-- Place me at ${HOME}/.config/qi/qibuild.xml -->
+<qibuild version="1">
+	<defaults>
+		<env />
+		<cmake generator="Unix Makefiles" />
+	</defaults>
+</qibuild>

--- a/scripts/vms/ubuntu-16/prepare-naoqi-requirements.sh
+++ b/scripts/vms/ubuntu-16/prepare-naoqi-requirements.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+sudo apt update
+
+sudo apt install --yes python
+
+echo "Downloading pip for Python 2.7"
+wget 'https://bootstrap.pypa.io/pip/2.7/get-pip.py'
+
+echo "Installing pip for Python 2.7"
+python2 get-pip.py

--- a/scripts/vms/ubuntu-16/reset-main-drive.sh
+++ b/scripts/vms/ubuntu-16/reset-main-drive.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+source './env-vars.sh'
+
+echo "Creating qcow2 main disk '${DISK_LOCATION}' with ${DISK_SIZE}"
+qemu-img create -f qcow2 "${DISK_LOCATION}" "${DISK_SIZE}"

--- a/scripts/vms/ubuntu-16/run-usb-hostbus.sh
+++ b/scripts/vms/ubuntu-16/run-usb-hostbus.sh
@@ -9,6 +9,8 @@ abort_if_bios_not_found
 abort_if_image_not_found
 abort_if_disk_not_found
 
+abort_if_usb_not_found
+
 qemu-system-x86_64 \
 -k pt-br \
 -machine "${MACHINE_CFG}" \
@@ -22,7 +24,7 @@ qemu-system-x86_64 \
 -netdev user,id=net0,net="${IPV4_NETWORK}",dhcpstart="${IPV4_DHCP_FIRST_ADDR}",hostfwd=tcp::"${P22_FWD}"-:22 \
 -device virtio-net-pci,netdev=net0 \
 -device qemu-xhci \
--device usb-host hostbus="${USB_HOST_BUS}",host_addr="${USB_HOST_ADDRESS}" \
+-device usb-host,hostdevice="${USB_FILE}" \
 -rtc base=localtime,clock=vm \
 -device "${DISPLAY_DEVICE}" \
 -display "${DISPLAY_BACKEND}" \

--- a/scripts/vms/ubuntu-16/run-usb-hostbus.sh
+++ b/scripts/vms/ubuntu-16/run-usb-hostbus.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+source './env-vars.sh'
+
+echo "Booting machine '${VM_NAME}' with HDD and packages' disk"
+
+abort_if_bios_not_found
+
+abort_if_image_not_found
+abort_if_disk_not_found
+
+qemu-system-x86_64 \
+-k pt-br \
+-machine "${MACHINE_CFG}" \
+-cpu "${CPU_MODEL}" -smp "${CPU_NUMBER}" \
+-m "${MACHINE_MEMORY_SIZE}" \
+-bios "${BIOS_LOCATION}" \
+-device virtio-scsi-pci,id=scsi0 \
+-drive file="${DISK_LOCATION}",format=qcow2,if=none,media=disk,index=0,id=drive-hd0,readonly=off \
+-device scsi-hd,bus=scsi0.0,drive=drive-hd0,id=hd0,bootindex=0 \
+-boot menu=on \
+-netdev user,id=net0,net="${IPV4_NETWORK}",dhcpstart="${IPV4_DHCP_FIRST_ADDR}",hostfwd=tcp::"${P22_FWD}"-:22 \
+-device virtio-net-pci,netdev=net0 \
+-device qemu-xhci \
+-device usb-host hostbus="${USB_HOST_BUS}",host_addr="${USB_HOST_ADDRESS}" \
+-rtc base=localtime,clock=vm \
+-device "${DISPLAY_DEVICE}" \
+-display "${DISPLAY_BACKEND}" \
+-monitor stdio \
+-name "${VM_NAME}"

--- a/scripts/vms/ubuntu-16/run-usb-hostbus.sh
+++ b/scripts/vms/ubuntu-16/run-usb-hostbus.sh
@@ -6,7 +6,6 @@ echo "Booting machine '${VM_NAME}' with HDD and packages' disk"
 
 abort_if_bios_not_found
 
-abort_if_image_not_found
 abort_if_disk_not_found
 
 abort_if_usb_not_found

--- a/scripts/vms/ubuntu-16/run-usb-productid.sh
+++ b/scripts/vms/ubuntu-16/run-usb-productid.sh
@@ -6,7 +6,6 @@ echo "Booting machine '${VM_NAME}' with HDD and packages' disk"
 
 abort_if_bios_not_found
 
-abort_if_image_not_found
 abort_if_disk_not_found
 
 abort_if_usb_misconfigured

--- a/scripts/vms/ubuntu-16/run-usb-productid.sh
+++ b/scripts/vms/ubuntu-16/run-usb-productid.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+source './env-vars.sh'
+
+echo "Booting machine '${VM_NAME}' with HDD and packages' disk"
+
+abort_if_bios_not_found
+
+abort_if_image_not_found
+abort_if_disk_not_found
+
+qemu-system-x86_64 \
+-k pt-br \
+-machine "${MACHINE_CFG}" \
+-cpu "${CPU_MODEL}" -smp "${CPU_NUMBER}" \
+-m "${MACHINE_MEMORY_SIZE}" \
+-bios "${BIOS_LOCATION}" \
+-device virtio-scsi-pci,id=scsi0 \
+-drive file="${DISK_LOCATION}",format=qcow2,if=none,media=disk,index=0,id=drive-hd0,readonly=off \
+-device scsi-hd,bus=scsi0.0,drive=drive-hd0,id=hd0,bootindex=0 \
+-boot menu=on \
+-netdev user,id=net0,net="${IPV4_NETWORK}",dhcpstart="${IPV4_DHCP_FIRST_ADDR}",hostfwd=tcp::"${P22_FWD}"-:22 \
+-device virtio-net-pci,netdev=net0 \
+-device qemu-xhci \
+-device usb-host vendorid="${USB_VENDOR_ID}",productid="${USB_PRODUCT_ID}" \
+-rtc base=localtime,clock=vm \
+-device "${DISPLAY_DEVICE}" \
+-display "${DISPLAY_BACKEND}" \
+-monitor stdio \
+-name "${VM_NAME}"

--- a/scripts/vms/ubuntu-16/run-usb-productid.sh
+++ b/scripts/vms/ubuntu-16/run-usb-productid.sh
@@ -9,6 +9,8 @@ abort_if_bios_not_found
 abort_if_image_not_found
 abort_if_disk_not_found
 
+abort_if_usb_misconfigured
+
 qemu-system-x86_64 \
 -k pt-br \
 -machine "${MACHINE_CFG}" \
@@ -22,7 +24,7 @@ qemu-system-x86_64 \
 -netdev user,id=net0,net="${IPV4_NETWORK}",dhcpstart="${IPV4_DHCP_FIRST_ADDR}",hostfwd=tcp::"${P22_FWD}"-:22 \
 -device virtio-net-pci,netdev=net0 \
 -device qemu-xhci \
--device usb-host vendorid="${USB_VENDOR_ID}",productid="${USB_PRODUCT_ID}" \
+-device usb-host,hostdevice="${USB_FILE}",vendorid="${USB_VENDOR_ID}",productid="${USB_PRODUCT_ID}" \
 -rtc base=localtime,clock=vm \
 -device "${DISPLAY_DEVICE}" \
 -display "${DISPLAY_BACKEND}" \

--- a/scripts/vms/ubuntu-16/run.sh
+++ b/scripts/vms/ubuntu-16/run.sh
@@ -6,7 +6,6 @@ echo "Booting machine '${VM_NAME}' with HDD and packages' disk"
 
 abort_if_bios_not_found
 
-abort_if_image_not_found
 abort_if_disk_not_found
 
 qemu-system-x86_64 \

--- a/scripts/vms/ubuntu-16/run.sh
+++ b/scripts/vms/ubuntu-16/run.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+source './env-vars.sh'
+
+echo "Booting machine '${VM_NAME}' with HDD and packages' disk"
+
+abort_if_bios_not_found
+
+abort_if_image_not_found
+abort_if_disk_not_found
+
+qemu-system-x86_64 \
+-k pt-br \
+-machine "${MACHINE_CFG}" \
+-cpu "${CPU_MODEL}" -smp "${CPU_NUMBER}" \
+-m "${MACHINE_MEMORY_SIZE}" \
+-bios "${BIOS_LOCATION}" \
+-device virtio-scsi-pci,id=scsi0 \
+-drive file="${DISK_LOCATION}",format=qcow2,if=none,media=disk,index=0,id=drive-hd0,readonly=off \
+-device scsi-hd,bus=scsi0.0,drive=drive-hd0,id=hd0,bootindex=0 \
+-device qemu-xhci \
+-boot menu=on \
+-netdev user,id=net0,net="${IPV4_NETWORK}",dhcpstart="${IPV4_DHCP_FIRST_ADDR}",hostfwd=tcp::"${P22_FWD}"-:22 \
+-device virtio-net-pci,netdev=net0 \
+-rtc base=localtime,clock=vm \
+-device "${DISPLAY_DEVICE}" \
+-display "${DISPLAY_BACKEND}" \
+-monitor stdio \
+-name "${VM_NAME}"

--- a/scripts/vms/ubuntu-16/sources.list
+++ b/scripts/vms/ubuntu-16/sources.list
@@ -1,0 +1,51 @@
+#deb cdrom:[Ubuntu 16.04.7 LTS _Xenial Xerus_ - Release amd64 (20200806)]/ xenial main restricted
+
+# See http://help.ubuntu.com/community/UpgradeNotes for how to upgrade to
+# newer versions of the distribution.
+deb http://archive.ubuntu.com/ubuntu/ xenial main restricted
+# deb-src http://archive.ubuntu.com/ubuntu/ xenial main restricted
+
+## Major bug fix updates produced after the final release of the
+## distribution.
+deb http://archive.ubuntu.com/ubuntu/ xenial-updates main restricted
+# deb-src http://archive.ubuntu.com/ubuntu/ xenial-updates main restricted
+
+## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
+## team. Also, please note that software in universe WILL NOT receive any
+## review or updates from the Ubuntu security team.
+deb http://archive.ubuntu.com/ubuntu/ xenial universe
+# deb-src http://archive.ubuntu.com/ubuntu/ xenial universe
+deb http://archive.ubuntu.com/ubuntu/ xenial-updates universe
+# deb-src http://archive.ubuntu.com/ubuntu/ xenial-updates universe
+
+## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu 
+## team, and may not be under a free licence. Please satisfy yourself as to 
+## your rights to use the software. Also, please note that software in 
+## multiverse WILL NOT receive any review or updates from the Ubuntu
+## security team.
+deb http://archive.ubuntu.com/ubuntu/ xenial multiverse
+# deb-src http://archive.ubuntu.com/ubuntu/ xenial multiverse
+deb http://archive.ubuntu.com/ubuntu/ xenial-updates multiverse
+# deb-src http://archive.ubuntu.com/ubuntu/ xenial-updates multiverse
+
+## N.B. software from this repository may not have been tested as
+## extensively as that contained in the main release, although it includes
+## newer versions of some applications which may provide useful features.
+## Also, please note that software in backports WILL NOT receive any review
+## or updates from the Ubuntu security team.
+deb http://archive.ubuntu.com/ubuntu/ xenial-backports main restricted universe multiverse
+# deb-src http://archive.ubuntu.com/ubuntu/ xenial-backports main restricted universe multiverse
+
+## Uncomment the following two lines to add software from Canonical's
+## 'partner' repository.
+## This software is not part of Ubuntu, but is offered by Canonical and the
+## respective vendors as a service to Ubuntu users.
+# deb http://archive.canonical.com/ubuntu xenial partner
+# deb-src http://archive.canonical.com/ubuntu xenial partner
+
+deb http://security.ubuntu.com/ubuntu xenial-security main restricted
+# deb-src http://security.ubuntu.com/ubuntu xenial-security main restricted
+deb http://security.ubuntu.com/ubuntu xenial-security universe
+# deb-src http://security.ubuntu.com/ubuntu xenial-security universe
+deb http://security.ubuntu.com/ubuntu xenial-security multiverse
+# deb-src http://security.ubuntu.com/ubuntu xenial-security multiverse

--- a/scripts/vms/ubuntu-16/update-sources.sh
+++ b/scripts/vms/ubuntu-16/update-sources.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/guestfish -f
+
+# Ugly hack yet necessary, as guestfish lacks variables
+# Guestfish asks 'sh' to interpret the inline script and will happily try to
+# execute whathever 'sh' sent to stdout
+<!. ./env-vars.sh > /dev/null; echo "add '${DISK_LOCATION}'"
+run
+mount '/dev/sda2' '/'
+
+echo "Copying from 'sources.list' to '/etc/apt/sources.list'"
+copy-in 'sources.list' '/etc/apt'
+
+echo ""
+
+echo "Unmounting..."
+umount-all
+
+echo "Done"
+
+exit


### PR DESCRIPTION
Adiciona script de instalação do ambiente do NAOv6 em uma máquina virtual (VM) do Ubuntu 16.04.

O script de instalação deve ser executado após o script de preparação, já disponível no repositório.

São instalados e configurados na máquina virtualizada:

- SDK C++ NAOv6
- SDK Python 2.7 NAOv6
- qibuild
- NAO Flasher
- Choregraphe NAOv6
- Robot Settings

A documentação do uso da VM foi atualizada com as instruções de uso do script de instalação.

Closes: ResidenciaTICBrisa/03_Robotica#53