### PR TITLE
Conserta travamentos, mouse desalinhado, BIOS imprópria, pedidos de interface

### DIFF
--- a/scripts/vms/ubuntu-14/README.md
+++ b/scripts/vms/ubuntu-14/README.md
@@ -96,6 +96,49 @@ archive:
 Don't forget to update (`apt-get update`) and upgrade (`apt-get dist-upgrade`)
 if there are any updates available.
 
+### How to reclaim unused memory from the Virtual Machine
+
+If you are running the virtual machine on a memory constrained host, we
+recommend you to use the included `virtio-balloon` functionality. This will
+recover unused memory from the virtual machine (the guest) and return it to your
+computer (the host).
+
+A balloon driver is a special driver included on the kernels of some operating
+systems that helps the hypervisors, programs used to run virtual machines, to
+recover unused memory from their guests. This drivers offers two operations: a
+balloon inflation and a deflation.
+
+The inflation procedure is used to reclaim unused memory: it orders the driver
+to create memory pressure on the guest machine, triggering a page update. This
+decreases the available memory in the guest, but it enables the host to reclaim
+any unused pages.
+
+The deflation procedure increases the available memory on the guest up its
+configured physical memory limit. It is commonly used after an inflation
+procedure to allow the virtual machine to use its configured physical memory.
+
+#### How to use the QEMU's balloon driver
+
+The QEMU's balloon driver is controlled in the QEMU monitor on the
+implementation offered by the scripts. The `balloon` command takes an argument
+that specifies the target logical size of the virtual machine:
+
+- if the argument is less than the physical memory configured for the VM, the
+balloon will be inflated in the guest, and any unused pages will be reclaimed;
+- if the argument is equal or greater than the guest's physical memory, the
+balloon will be deflated until it no longer restricts the virtual machine's
+physical memory.
+
+Please be aware that the `virtio-balloon` does not require the installation of
+any external driver on most GNU/Linux-based guests, as it is included in the
+kernel since 2008 (version 2.6.25).
+
+It is important to always have in mind that the balloon inflation operation
+should only be performed when the virtual machine is not under memory pressure.
+This means that you should only try to recover **unused** memory from the
+VM when it has a healthy amount of free memory to keep running without needing
+to swap.
+
 ## Preparing to install NAOqi for NAOv4
 
 Ubuntu 14.04 has an old version of Python 2.7. It lacks support to download data

--- a/scripts/vms/ubuntu-14/env-vars.sh
+++ b/scripts/vms/ubuntu-14/env-vars.sh
@@ -63,7 +63,6 @@ echo "CPU_NUMBER=${CPU_NUMBER:?${UNSET_WARNING}}"
 echo "MACHINE_MEMORY_SIZE=${MACHINE_MEMORY_SIZE:?${UNSET_WARNING}}"
 
 echo "BRIDGE=${BRIDGE:?${UNSET_WARNING}}"
-#echo "INTERFACE=${INTERFACE:?${UNSET_WARNING}}"
 echo "BRIDGE_IP=${BRIDGE_IP:?${UNSET_WARNING}}"
 echo "DNSMASQ_IP_START=${DNSMASQ_IP_START:?${UNSET_WARNING}}"
 echo "DNSMASQ_IP_END=${DNSMASQ_IP_END:?${UNSET_WARNING}}"
@@ -141,6 +140,8 @@ abort_if_nftables_not_found() {
 }
 
 abort_if_interface_not_found() {
+	echo "INTERFACE=${INTERFACE:?${UNSET_WARNING}}"
+
 	if ! ip link show "${INTERFACE}" >/dev/null; then
 		echo "Device ${INTERFACE} does not exist"
 		echo 8

--- a/scripts/vms/ubuntu-14/env-vars.sh
+++ b/scripts/vms/ubuntu-14/env-vars.sh
@@ -3,7 +3,7 @@
 # [ -z "${VAR}" ] && echo "unset" || echo "set"
 [ -z "${SOURCED_ENV_VARS_SH}" ] || exit 0
 
-readonly BIOS_LOCATION="/usr/share/seabios/vgabios-virtio.bin"
+readonly BIOS_LOCATION="/usr/share/seabios/bios-256k.bin"
 readonly IMAGE_LOCATION="ubuntu-14.04-desktop-amd64.iso"
 readonly DISK_LOCATION="ubuntu-14.04-vm.qcow2"
 
@@ -63,7 +63,7 @@ echo "CPU_NUMBER=${CPU_NUMBER:?${UNSET_WARNING}}"
 echo "MACHINE_MEMORY_SIZE=${MACHINE_MEMORY_SIZE:?${UNSET_WARNING}}"
 
 echo "BRIDGE=${BRIDGE:?${UNSET_WARNING}}"
-echo "INTERFACE=${INTERFACE:?${UNSET_WARNING}}"
+#echo "INTERFACE=${INTERFACE:?${UNSET_WARNING}}"
 echo "BRIDGE_IP=${BRIDGE_IP:?${UNSET_WARNING}}"
 echo "DNSMASQ_IP_START=${DNSMASQ_IP_START:?${UNSET_WARNING}}"
 echo "DNSMASQ_IP_END=${DNSMASQ_IP_END:?${UNSET_WARNING}}"

--- a/scripts/vms/ubuntu-14/env-vars.sh
+++ b/scripts/vms/ubuntu-14/env-vars.sh
@@ -19,7 +19,7 @@ readonly MACHINE_CFG="type=${MACHINE_TYPE},accel=kvm"
 readonly CPU_MODEL="Haswell-v4"
 readonly CPU_NUMBER="4"
 readonly MACHINE_MEMORY_SIZE="4G"
-readonly DISPLAY_DEVICE="qxl-vga"
+readonly DISPLAY_DEVICE="vmware-svga,vgamem_mb=32"
 readonly DISPLAY_BACKEND="gtk"
 
 readonly VM_USER="softex"

--- a/scripts/vms/ubuntu-14/install-naov4.sh
+++ b/scripts/vms/ubuntu-14/install-naov4.sh
@@ -78,6 +78,9 @@ sudo apt-get update
 printf 'Install C++, Python dependencies and downloader\n'
 sudo apt-get install --yes build-essential cmake wget
 
+printf 'Install editors\n'
+sudo apt-get install --yes vim vim-gtk
+
 printf 'Create directories\n'
 for directory in "${DIRECTORIES[@]}"; do
 	mkdir -pv "${directory}"

--- a/scripts/vms/ubuntu-14/run-nat-bridge.sh
+++ b/scripts/vms/ubuntu-14/run-nat-bridge.sh
@@ -23,6 +23,7 @@ qemu-system-x86_64 \
 -device virtio-net-pci,netdev=net0,mac="${VM_MAC}" \
 -rtc base=localtime,clock=vm \
 -device "${DISPLAY_DEVICE}" \
+-device usb-tablet \
 -display "${DISPLAY_BACKEND}" \
 -monitor stdio \
 -name "${VM_NAME}"

--- a/scripts/vms/ubuntu-14/run-nat-bridge.sh
+++ b/scripts/vms/ubuntu-14/run-nat-bridge.sh
@@ -22,6 +22,7 @@ qemu-system-x86_64 \
 -netdev bridge,id=net0,br="${BRIDGE}" \
 -device virtio-net-pci,netdev=net0,mac="${VM_MAC}" \
 -rtc base=localtime,clock=vm \
+-device virtio-balloon \
 -device "${DISPLAY_DEVICE}" \
 -device usb-tablet \
 -display "${DISPLAY_BACKEND}" \

--- a/scripts/vms/ubuntu-14/run-usb-hostbus.sh
+++ b/scripts/vms/ubuntu-14/run-usb-hostbus.sh
@@ -25,6 +25,7 @@ qemu-system-x86_64 \
 -device qemu-xhci \
 -device usb-host,hostdevice="${USB_FILE}" \
 -rtc base=localtime,clock=vm \
+-device virtio-balloon \
 -device "${DISPLAY_DEVICE}" \
 -device usb-tablet \
 -display "${DISPLAY_BACKEND}" \

--- a/scripts/vms/ubuntu-14/run-usb-hostbus.sh
+++ b/scripts/vms/ubuntu-14/run-usb-hostbus.sh
@@ -26,6 +26,7 @@ qemu-system-x86_64 \
 -device usb-host,hostdevice="${USB_FILE}" \
 -rtc base=localtime,clock=vm \
 -device "${DISPLAY_DEVICE}" \
+-device usb-tablet \
 -display "${DISPLAY_BACKEND}" \
 -monitor stdio \
 -name "${VM_NAME}"

--- a/scripts/vms/ubuntu-14/run-usb-productid.sh
+++ b/scripts/vms/ubuntu-14/run-usb-productid.sh
@@ -25,6 +25,7 @@ qemu-system-x86_64 \
 -device qemu-xhci \
 -device usb-host,hostdevice="${USB_FILE}",vendorid="${USB_VENDOR_ID}",productid="${USB_PRODUCT_ID}" \
 -rtc base=localtime,clock=vm \
+-device virtio-balloon \
 -device "${DISPLAY_DEVICE}" \
 -device usb-tablet \
 -display "${DISPLAY_BACKEND}" \

--- a/scripts/vms/ubuntu-14/run-usb-productid.sh
+++ b/scripts/vms/ubuntu-14/run-usb-productid.sh
@@ -26,6 +26,7 @@ qemu-system-x86_64 \
 -device usb-host,hostdevice="${USB_FILE}",vendorid="${USB_VENDOR_ID}",productid="${USB_PRODUCT_ID}" \
 -rtc base=localtime,clock=vm \
 -device "${DISPLAY_DEVICE}" \
+-device usb-tablet \
 -display "${DISPLAY_BACKEND}" \
 -monitor stdio \
 -name "${VM_NAME}"

--- a/scripts/vms/ubuntu-14/run.sh
+++ b/scripts/vms/ubuntu-14/run.sh
@@ -23,6 +23,7 @@ qemu-system-x86_64 \
 -device virtio-net-pci,netdev=net0 \
 -rtc base=localtime,clock=vm \
 -device "${DISPLAY_DEVICE}" \
+-device usb-tablet \
 -display "${DISPLAY_BACKEND}" \
 -monitor stdio \
 -name "${VM_NAME}"

--- a/scripts/vms/ubuntu-14/run.sh
+++ b/scripts/vms/ubuntu-14/run.sh
@@ -22,6 +22,7 @@ qemu-system-x86_64 \
 -netdev user,id=net0,net="${IPV4_NETWORK}",dhcpstart="${IPV4_DHCP_FIRST_ADDR}",hostfwd=tcp::"${P22_FWD}"-:22 \
 -device virtio-net-pci,netdev=net0 \
 -rtc base=localtime,clock=vm \
+-device virtio-balloon \
 -device "${DISPLAY_DEVICE}" \
 -device usb-tablet \
 -display "${DISPLAY_BACKEND}" \

--- a/scripts/vms/ubuntu-16/README.md
+++ b/scripts/vms/ubuntu-16/README.md
@@ -94,6 +94,49 @@ archive:
 Don't forget to update (`apt update`) and upgrade (`apt dist-upgrade`) if there
 are any updates available.
 
+### How to reclaim unused memory from the Virtual Machine
+
+If you are running the virtual machine on a memory constrained host, we
+recommend you to use the included `virtio-balloon` functionality. This will
+recover unused memory from the virtual machine (the guest) and return it to your
+computer (the host).
+
+A balloon driver is a special driver included on the kernels of some operating
+systems that helps the hypervisors, programs used to run virtual machines, to
+recover unused memory from their guests. This drivers offers two operations: a
+balloon inflation and a deflation.
+
+The inflation procedure is used to reclaim unused memory: it orders the driver
+to create memory pressure on the guest machine, triggering a page update. This
+decreases the available memory in the guest, but it enables the host to reclaim
+any unused pages.
+
+The deflation procedure increases the available memory on the guest up its
+configured physical memory limit. It is commonly used after an inflation
+procedure to allow the virtual machine to use its configured physical memory.
+
+#### How to use the QEMU's balloon driver
+
+The QEMU's balloon driver is controlled in the QEMU monitor on the
+implementation offered by the scripts. The `balloon` command takes an argument
+that specifies the target logical size of the virtual machine:
+
+- if the argument is less than the physical memory configured for the VM, the
+balloon will be inflated in the guest, and any unused pages will be reclaimed;
+- if the argument is equal or greater than the guest's physical memory, the
+balloon will be deflated until it no longer restricts the virtual machine's
+physical memory.
+
+Please be aware that the `virtio-balloon` does not require the installation of
+any external driver on most GNU/Linux-based guests, as it is included in the
+kernel since 2008 (version 2.6.25).
+
+It is important to always have in mind that the balloon inflation operation
+should only be performed when the virtual machine is not under memory pressure.
+This means that you should only try to recover **unused** memory from the
+VM when it has a healthy amount of free memory to keep running without needing
+to swap.
+
 ## Preparing to install NAOqi for NAOv6
 
 Ubuntu 16.04 has an old version of `pip`. This requires an installation of the

--- a/scripts/vms/ubuntu-16/env-vars.sh
+++ b/scripts/vms/ubuntu-16/env-vars.sh
@@ -31,7 +31,7 @@ readonly USB_PRODUCT_ID=""
 readonly USB_FILE="/dev/bus/usb/${USB_HOST_BUS}/${USB_HOST_ADDRESS}"
 
 readonly BRIDGE="qemubr0"
-readonly INTERFACE="wlp0s20f3"
+readonly INTERFACE=""
 readonly BRIDGE_IP="10.14.1.15/16"
 readonly DNSMASQ_IP_START="10.14.1.16"
 readonly DNSMASQ_IP_END="10.14.1.254"
@@ -63,7 +63,6 @@ echo "CPU_NUMBER=${CPU_NUMBER:?${UNSET_WARNING}}"
 echo "MACHINE_MEMORY_SIZE=${MACHINE_MEMORY_SIZE:?${UNSET_WARNING}}"
 
 echo "BRIDGE=${BRIDGE:?${UNSET_WARNING}}"
-echo "INTERFACE=${INTERFACE:?${UNSET_WARNING}}"
 echo "BRIDGE_IP=${BRIDGE_IP:?${UNSET_WARNING}}"
 echo "DNSMASQ_IP_START=${DNSMASQ_IP_START:?${UNSET_WARNING}}"
 echo "DNSMASQ_IP_END=${DNSMASQ_IP_END:?${UNSET_WARNING}}"
@@ -141,6 +140,8 @@ abort_if_nftables_not_found() {
 }
 
 abort_if_interface_not_found() {
+	echo "INTERFACE=${INTERFACE:?${UNSET_WARNING}}"
+
 	if ! ip link show "${INTERFACE}" >/dev/null; then
 		echo "Device ${INTERFACE} does not exist"
 		echo 8

--- a/scripts/vms/ubuntu-16/install-naov6.sh
+++ b/scripts/vms/ubuntu-16/install-naov6.sh
@@ -86,6 +86,9 @@ sudo apt-get update
 printf 'Install C++, Python dependencies and downloader\n'
 sudo apt-get install --yes build-essential cmake wget
 
+printf 'Install editors\n'
+sudo apt-get install --yes vim vim-gtk3
+
 printf 'Create directories\n'
 for directory in "${DIRECTORIES[@]}"; do
 	mkdir -pv "${directory}"

--- a/scripts/vms/ubuntu-16/run-nat-bridge.sh
+++ b/scripts/vms/ubuntu-16/run-nat-bridge.sh
@@ -23,6 +23,7 @@ qemu-system-x86_64 \
 -device virtio-net-pci,netdev=net0,mac="${VM_MAC}" \
 -rtc base=localtime,clock=vm \
 -device "${DISPLAY_DEVICE}" \
+-device usb-tablet \
 -display "${DISPLAY_BACKEND}" \
 -monitor stdio \
 -name "${VM_NAME}"

--- a/scripts/vms/ubuntu-16/run-nat-bridge.sh
+++ b/scripts/vms/ubuntu-16/run-nat-bridge.sh
@@ -22,6 +22,7 @@ qemu-system-x86_64 \
 -netdev bridge,id=net0,br="${BRIDGE}" \
 -device virtio-net-pci,netdev=net0,mac="${VM_MAC}" \
 -rtc base=localtime,clock=vm \
+-device virtio-balloon \
 -device "${DISPLAY_DEVICE}" \
 -device usb-tablet \
 -display "${DISPLAY_BACKEND}" \

--- a/scripts/vms/ubuntu-16/run-usb-hostbus.sh
+++ b/scripts/vms/ubuntu-16/run-usb-hostbus.sh
@@ -25,6 +25,7 @@ qemu-system-x86_64 \
 -device qemu-xhci \
 -device usb-host,hostdevice="${USB_FILE}" \
 -rtc base=localtime,clock=vm \
+-device virtio-balloon \
 -device "${DISPLAY_DEVICE}" \
 -device usb-tablet \
 -display "${DISPLAY_BACKEND}" \

--- a/scripts/vms/ubuntu-16/run-usb-hostbus.sh
+++ b/scripts/vms/ubuntu-16/run-usb-hostbus.sh
@@ -26,6 +26,7 @@ qemu-system-x86_64 \
 -device usb-host,hostdevice="${USB_FILE}" \
 -rtc base=localtime,clock=vm \
 -device "${DISPLAY_DEVICE}" \
+-device usb-tablet \
 -display "${DISPLAY_BACKEND}" \
 -monitor stdio \
 -name "${VM_NAME}"

--- a/scripts/vms/ubuntu-16/run-usb-productid.sh
+++ b/scripts/vms/ubuntu-16/run-usb-productid.sh
@@ -25,6 +25,7 @@ qemu-system-x86_64 \
 -device qemu-xhci \
 -device usb-host,hostdevice="${USB_FILE}",vendorid="${USB_VENDOR_ID}",productid="${USB_PRODUCT_ID}" \
 -rtc base=localtime,clock=vm \
+-device virtio-balloon \
 -device "${DISPLAY_DEVICE}" \
 -device usb-tablet \
 -display "${DISPLAY_BACKEND}" \

--- a/scripts/vms/ubuntu-16/run-usb-productid.sh
+++ b/scripts/vms/ubuntu-16/run-usb-productid.sh
@@ -26,6 +26,7 @@ qemu-system-x86_64 \
 -device usb-host,hostdevice="${USB_FILE}",vendorid="${USB_VENDOR_ID}",productid="${USB_PRODUCT_ID}" \
 -rtc base=localtime,clock=vm \
 -device "${DISPLAY_DEVICE}" \
+-device usb-tablet \
 -display "${DISPLAY_BACKEND}" \
 -monitor stdio \
 -name "${VM_NAME}"

--- a/scripts/vms/ubuntu-16/run.sh
+++ b/scripts/vms/ubuntu-16/run.sh
@@ -23,6 +23,7 @@ qemu-system-x86_64 \
 -device virtio-net-pci,netdev=net0 \
 -rtc base=localtime,clock=vm \
 -device "${DISPLAY_DEVICE}" \
+-device usb-tablet \
 -display "${DISPLAY_BACKEND}" \
 -monitor stdio \
 -name "${VM_NAME}"

--- a/scripts/vms/ubuntu-16/run.sh
+++ b/scripts/vms/ubuntu-16/run.sh
@@ -22,6 +22,7 @@ qemu-system-x86_64 \
 -netdev user,id=net0,net="${IPV4_NETWORK}",dhcpstart="${IPV4_DHCP_FIRST_ADDR}",hostfwd=tcp::"${P22_FWD}"-:22 \
 -device virtio-net-pci,netdev=net0 \
 -rtc base=localtime,clock=vm \
+-device virtio-balloon \
 -device "${DISPLAY_DEVICE}" \
 -device usb-tablet \
 -display "${DISPLAY_BACKEND}" \


### PR DESCRIPTION
- troca o driver QXL pelo VMWare SVGA, eliminando o problema de travamentos repentinos no Ubuntu 14
- corrige o desalinhamento entre o mouse do computador anfitrião e da máquina virtual no Ubuntu 16
- troca a `vgabios-virtio` pela `bios-256k`, pois a primeira é desnecessária já que não há suporte para os drivers gráficos `virtio` no Ubuntu 14
- adiciona driver `virtio-balloon` e documenta seu uso no QEMU monitor para liberar memória não usada pelas máquinas virtuais
- adiciona `vim` e `vim-gtk` ao processo de instalação

Closes: ResidenciaTICBrisa/03_Robotica#64
Closes: ResidenciaTICBrisa/03_Robotica#68
Closes: ResidenciaTICBrisa/03_Robotica#69
Closes: ResidenciaTICBrisa/03_Robotica#70
Closes: ResidenciaTICBrisa/03_Robotica#73
Closes: ResidenciaTICBrisa/03_Robotica#74